### PR TITLE
Aram mode, adding filler, higher character start count, COOP mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -382,7 +382,7 @@ class BuildExeCommand(cx_Freeze.command.build_exe.BuildEXE):
                 with zipfile.ZipFile(self.libfolder / "worlds" / (file_name + ".apworld"), "x", zipfile.ZIP_DEFLATED,
                                      compresslevel=9) as zf:
                     for path in world_directory.rglob("*.*"):
-                        relative_path = os.path.join(*path.parts[path.parts.index("worlds")+1:])
+                        relative_path = "/".join(path.parts[path.parts.index("worlds") + 1:])
                         zf.write(path, relative_path)
                     folders_to_remove.append(file_name)
                 shutil.rmtree(world_directory)

--- a/worlds/lol/Client.py
+++ b/worlds/lol/Client.py
@@ -48,6 +48,9 @@ class LOLContext(CommonContext):
         self.send_index: int = 0
         self.syncing = False
         self.awaiting_bridge = False
+        self.lp_label = None
+        self.required_lp: int = 0
+        self.win_completes_champion: bool = False
         # self.game_communication_path: files go in this path to pass data between us and the actual game
         if "localappdata" in os.environ:
             self.game_communication_path = os.path.expandvars(r"%localappdata%/LOLAP")
@@ -101,6 +104,16 @@ class LOLContext(CommonContext):
                     f.write(str(args['slot_data'][slot_data_key]))
                     f.close()
             #End Handle Slot Data
+            self.required_lp = int(args['slot_data'].get('Required LP', 0))
+            self.win_completes_champion = bool(args['slot_data'].get('Win Completes Champion', False))
+            # win_completes_champion sibling filter uses ctx.missing_locations (set after Connected)
+            # Write a checked locations file for tools (list of ids)
+            try:
+                with open(os.path.join(self.game_communication_path, "Checked_Locations.cfg"), 'w') as f:
+                    f.write(str(list(self.checked_locations)))
+                    f.close()
+            except Exception:
+                pass
             
         if cmd in {"ReceivedItems"}:
             start_index = args["index"]
@@ -135,6 +148,28 @@ class LOLContext(CommonContext):
                     filename = f"send{ss}"
                     with open(os.path.join(self.game_communication_path, filename), 'w') as f:
                         f.close()
+            # update checked locations file
+            try:
+                with open(os.path.join(self.game_communication_path, "Checked_Locations.cfg"), 'w') as f:
+                    f.write(str(list(self.checked_locations)))
+                    f.close()
+            except Exception:
+                pass
+
+    async def draw_lp_counter(self):
+        try:
+            from kvui import MDLabel as Label
+        except ImportError:
+            from kvui import Label
+        # Only show LP counter when we've got a slot and a non-zero required LP
+        if not getattr(self, 'slot', None) or not self.required_lp:
+            return
+        if not self.lp_label:
+            # make the label smaller so it doesn't take too much space
+            self.lp_label = Label(text="", size_hint_x=None, width=84, halign="center")
+            self.ui.connect_layout.add_widget(self.lp_label)
+        current_lp = sum(1 for item in self.items_received if item.item == 565_000000)
+        self.lp_label.text = f"LP: {current_lp}/{self.required_lp}"
 
     def run_gui(self):
         """Import kivy UI system and start running it as self.ui_task."""
@@ -144,7 +179,7 @@ class LOLContext(CommonContext):
             logging_pairs = [
                 ("Client", "Archipelago")
             ]
-            base_title = "Archipelago LOL Client"
+            base_title = "Archipelago LoL Client"
 
         self.ui = LOLManager(self)
         self.ui_task = asyncio.create_task(self.ui.async_run(), name="UI")
@@ -169,7 +204,38 @@ async def game_watcher(ctx: LOLContext):
                         sending = sending+[(int(st))]
                 if file.find("victory") > -1:
                     victory = True
+        # Win Completes Champion: auto-send all sibling locations when nexus is destroyed
+        if ctx.win_completes_champion:
+            all_active = ctx.missing_locations | ctx.checked_locations
+            new_sends = []
+            for loc_id in list(sending):
+                # "Enemy Nexus Destroyed" locations have offset 10 in the ID scheme
+                if loc_id in lookup_id_to_name and "Enemy Nexus Destroyed" in lookup_id_to_name[loc_id]:
+                    champ_bucket = (loc_id - 566_000000) // 100
+                    for sibling_id, sibling_name in lookup_id_to_name.items():
+                        sibling_relative = sibling_id - 566_000000
+                        if (sibling_relative > 0
+                                and sibling_relative // 100 == champ_bucket
+                                and sibling_id not in sending
+                                and sibling_id not in new_sends
+                                and sibling_id in all_active):
+                            sibling_path = os.path.join(ctx.game_communication_path, f"send{sibling_id}")
+                            if not os.path.exists(sibling_path):
+                                with open(sibling_path, 'w') as f:
+                                    pass
+                            new_sends.append(sibling_id)
+            sending.extend(new_sends)
+
         ctx.locations_checked = sending
+        if ctx.ui:
+            await ctx.draw_lp_counter()
+        # persist checked locations for external tools
+        try:
+            with open(os.path.join(ctx.game_communication_path, "Checked_Locations.cfg"), 'w') as f:
+                f.write(str(list(ctx.locations_checked)))
+                f.close()
+        except Exception:
+            pass
         message = [{"cmd": 'LocationChecks', "locations": sending}]
         await ctx.send_msgs(message)
         if not ctx.finished_game and victory:
@@ -197,7 +263,7 @@ def launch():
 
     import colorama
 
-    parser = get_base_parser(description="LOL Client, for text interfacing.")
+    parser = get_base_parser(description="LoL Client, for text interfacing.")
 
     args, rest = parser.parse_known_args()
     colorama.init()

--- a/worlds/lol/Client.py
+++ b/worlds/lol/Client.py
@@ -30,16 +30,35 @@ from NetUtils import NetworkItem, ClientStatus
 from CommonClient import gui_enabled, logger, get_base_parser, ClientCommandProcessor, \
     CommonContext, server_loop
 
+tracker_loaded = False
+try:
+    from worlds.tracker.TrackerClient import TrackerGameContext as SuperContext
+    tracker_loaded = True
+except ModuleNotFoundError:
+    SuperContext = CommonContext
+
 
 def check_stdin() -> None:
     if Utils.is_windows and sys.stdin:
         print("WARNING: Console input is not routed reliably on Windows, use the GUI instead.")
 
 class LOLClientCommandProcessor(ClientCommandProcessor):
-    pass
+    def _cmd_send_starting_champions(self):
+        """Manually trigger the starting champion location checks."""
+        ctx: LOLContext = self.ctx
+        starting_count = int(ctx.slot_data.get('Starting Champion Count', 0)) if ctx.slot_data else 0
+        if starting_count == 0:
+            logger.info("No starting champions configured for this slot.")
+            return
+        for i in range(1, starting_count + 1):
+            filepath = os.path.join(ctx.game_communication_path, f"send{566_000000 + i}")
+            with open(filepath, 'w') as f:
+                pass
+        logger.info(f"Triggered {starting_count} starting champion check(s).")
 
-class LOLContext(CommonContext):
+class LOLContext(SuperContext):
     command_processor: int = LOLClientCommandProcessor
+    tags = {"AP"}
     game = "League of Legends"
     items_handling = 0b111  # full remote
 
@@ -51,6 +70,7 @@ class LOLContext(CommonContext):
         self.lp_label = None
         self.required_lp: int = 0
         self.win_completes_champion: bool = False
+        self.slot_data: dict = {}
         # self.game_communication_path: files go in this path to pass data between us and the actual game
         if "localappdata" in os.environ:
             self.game_communication_path = os.path.expandvars(r"%localappdata%/LOLAP")
@@ -91,6 +111,7 @@ class LOLContext(CommonContext):
                     os.remove(root+"/"+file)
 
     def on_package(self, cmd: str, args: dict):
+        super().on_package(cmd, args)
         if cmd in {"Connected"}:
             if not os.path.exists(self.game_communication_path):
                 os.makedirs(self.game_communication_path)
@@ -106,6 +127,13 @@ class LOLContext(CommonContext):
             #End Handle Slot Data
             self.required_lp = int(args['slot_data'].get('Required LP', 0))
             self.win_completes_champion = bool(args['slot_data'].get('Win Completes Champion', False))
+            self.slot_data = args['slot_data']
+            # Auto-send starting champion checks so players receive them immediately
+            starting_count = int(args['slot_data'].get('Starting Champion Count', 0))
+            for i in range(1, starting_count + 1):
+                filepath = os.path.join(self.game_communication_path, f"send{566_000000 + i}")
+                with open(filepath, 'w') as f:
+                    pass
             # win_completes_champion sibling filter uses ctx.missing_locations (set after Connected)
             # Write a checked locations file for tools (list of ids)
             try:
@@ -248,6 +276,8 @@ def launch():
     async def main(args):
         ctx = LOLContext(args.connect, args.password)
         ctx.server_task = asyncio.create_task(server_loop(ctx), name="server loop")
+        if tracker_loaded:
+            ctx.run_generator()
         if gui_enabled:
             ctx.run_gui()
         ctx.run_cli()

--- a/worlds/lol/Client.py
+++ b/worlds/lol/Client.py
@@ -73,6 +73,7 @@ class LOLContext(SuperContext):
         self.slot_data: dict = {}
         self._received_items_cache: set = set()  # (item, location, player) already written to disk
         self._last_locations_sent: set = set()  # last set sent in LocationChecks
+        self._last_active_location_ids_written: set = set()
         # self.game_communication_path: files go in this path to pass data between us and the actual game
         if "localappdata" in os.environ:
             self.game_communication_path = os.path.expandvars(r"%localappdata%/LOLAP")
@@ -286,12 +287,55 @@ async def game_watcher(ctx: LOLContext):
         victory = False
         for root, dirs, files in os.walk(ctx.game_communication_path):
             for file in files:
-                if file.find("send") > -1:
-                    st = file.split("send", -1)[1]
-                    if st != "nil":
-                        sending = sending+[(int(st))]
+                if file.startswith("send"):
+                    st = file[4:]
+                    if st == "nil":
+                        continue
+                    if st.isdigit():
+                        sending.append(int(st))
                 if file.find("victory") > -1:
                     victory = True
+
+        # Guard against stale/foreign send files from previous sessions or slots.
+        # Only location IDs that belong to this slot's active location universe are valid.
+        active_ids = ctx.missing_locations | ctx.checked_locations
+        if active_ids != ctx._last_active_location_ids_written:
+            ctx._last_active_location_ids_written = set(active_ids)
+            active_location_ids = {
+                lookup_id_to_name[loc_id]: loc_id
+                for loc_id in sorted(active_ids)
+                if loc_id in lookup_id_to_name
+            }
+            active_locations = list(active_location_ids.keys())
+            try:
+                with open(os.path.join(ctx.game_communication_path, "Active_Location_IDs.cfg"), 'w') as f:
+                    f.write(str(active_location_ids))
+            except Exception:
+                pass
+            try:
+                with open(os.path.join(ctx.game_communication_path, "Active_Locations.cfg"), 'w') as f:
+                    f.write(str(active_locations))
+            except Exception:
+                pass
+
+        sending_set_pre_filter = set(sending)
+        if active_ids:
+            sending = [loc_id for loc_id in sending if loc_id in active_ids]
+        else:
+            # No active location universe yet: drop all queued send files as stale.
+            sending = []
+        stale_ids = sending_set_pre_filter - set(sending)
+        for stale_id in stale_ids:
+            stale_path = os.path.join(ctx.game_communication_path, f"send{stale_id}")
+            try:
+                os.remove(stale_path)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                pass
+
+        # Deduplicate while preserving deterministic ordering for cfg/messages.
+        sending = sorted(set(sending))
         # Win Completes Champion: auto-send all sibling locations when nexus is destroyed
         if ctx.win_completes_champion:
             all_active = ctx.missing_locations | ctx.checked_locations

--- a/worlds/lol/Client.py
+++ b/worlds/lol/Client.py
@@ -71,6 +71,8 @@ class LOLContext(SuperContext):
         self.required_lp: int = 0
         self.win_completes_champion: bool = False
         self.slot_data: dict = {}
+        self._received_items_cache: set = set()  # (item, location, player) already written to disk
+        self._last_locations_sent: set = set()  # last set sent in LocationChecks
         # self.game_communication_path: files go in this path to pass data between us and the actual game
         if "localappdata" in os.environ:
             self.game_communication_path = os.path.expandvars(r"%localappdata%/LOLAP")
@@ -115,10 +117,17 @@ class LOLContext(SuperContext):
         if cmd in {"Connected"}:
             if not os.path.exists(self.game_communication_path):
                 os.makedirs(self.game_communication_path)
-            for ss in self.checked_locations:
-                filename = f"send{ss}"
-                with open(os.path.join(self.game_communication_path, filename), 'w') as f:
-                    f.close()
+            # Offload bulk file creation to a thread so the event loop stays responsive
+            checked = list(self.checked_locations)
+            comm_path = self.game_communication_path
+            def _write_send_files():
+                for ss in checked:
+                    filename = f"send{ss}"
+                    filepath = os.path.join(comm_path, filename)
+                    if not os.path.exists(filepath):
+                        with open(filepath, 'w') as f:
+                            pass
+            asyncio.get_event_loop().run_in_executor(None, _write_send_files)
             #Handle Slot Data
             for slot_data_key in list(args['slot_data'].keys()):
                 with open(os.path.join(self.game_communication_path, slot_data_key.replace(" ", "_") + ".cfg"), 'w') as f:
@@ -146,29 +155,39 @@ class LOLContext(SuperContext):
         if cmd in {"ReceivedItems"}:
             start_index = args["index"]
             if start_index != len(self.items_received):
+                # Seed the in-memory cache from disk on first use (e.g. after reconnect)
+                if not self._received_items_cache:
+                    try:
+                        for filename in os.listdir(self.game_communication_path):
+                            if filename.startswith("AP") and filename.endswith(".item"):
+                                with open(os.path.join(self.game_communication_path, filename), 'r') as f:
+                                    lines = f.read().splitlines()
+                                if len(lines) >= 3:
+                                    self._received_items_cache.add((lines[0], lines[1], lines[2]))
+                    except Exception:
+                        pass
+                # Find next file index once
+                check_num = 0
+                try:
+                    for filename in os.listdir(self.game_communication_path):
+                        if filename.startswith("AP") and filename.endswith(".item"):
+                            try:
+                                n = int(filename.split("_")[-1].split(".")[0])
+                                if n > check_num:
+                                    check_num = n
+                            except ValueError:
+                                pass
+                except Exception:
+                    pass
                 for item in args['items']:
-                    check_num = 0
-                    for filename in os.listdir(self.game_communication_path):
-                        if filename.startswith("AP"):
-                            if int(filename.split("_")[-1].split(".")[0]) > check_num:
-                                check_num = int(filename.split("_")[-1].split(".")[0])
-                    item_id = ""
-                    location_id = ""
-                    player = ""
-                    found = False
-                    for filename in os.listdir(self.game_communication_path):
-                        if filename.startswith(f"AP"):
-                            with open(os.path.join(self.game_communication_path, filename), 'r') as f:
-                                item_id = str(f.readline()).replace("\n", "")
-                                location_id = str(f.readline()).replace("\n", "")
-                                player = str(f.readline()).replace("\n", "")
-                                if str(item_id) == str(NetworkItem(*item).item) and str(location_id) == str(NetworkItem(*item).location) and str(player) == str(NetworkItem(*item).player) and int(location_id) > 0:
-                                    found = True
-                    if not found:
-                        filename = f"AP_{str(check_num+1)}.item"
+                    net_item = NetworkItem(*item)
+                    key = (str(net_item.item), str(net_item.location), str(net_item.player))
+                    if key not in self._received_items_cache and int(net_item.location) > 0:
+                        check_num += 1
+                        filename = f"AP_{check_num}.item"
                         with open(os.path.join(self.game_communication_path, filename), 'w') as f:
-                            f.write(str(NetworkItem(*item).item) + "\n" + str(NetworkItem(*item).location) + "\n" + str(NetworkItem(*item).player))
-                            f.close()
+                            f.write(f"{net_item.item}\n{net_item.location}\n{net_item.player}")
+                        self._received_items_cache.add(key)
 
         if cmd in {"RoomUpdate"}:
             if "checked_locations" in args:
@@ -254,18 +273,20 @@ async def game_watcher(ctx: LOLContext):
                             new_sends.append(sibling_id)
             sending.extend(new_sends)
 
+        sending_set = set(sending)
         ctx.locations_checked = sending
         if ctx.ui:
             await ctx.draw_lp_counter()
-        # persist checked locations for external tools
-        try:
-            with open(os.path.join(ctx.game_communication_path, "Checked_Locations.cfg"), 'w') as f:
-                f.write(str(list(ctx.locations_checked)))
-                f.close()
-        except Exception:
-            pass
-        message = [{"cmd": 'LocationChecks', "locations": sending}]
-        await ctx.send_msgs(message)
+        # Only write cfg and send LocationChecks when the set has actually changed
+        if sending_set != ctx._last_locations_sent:
+            ctx._last_locations_sent = sending_set
+            try:
+                with open(os.path.join(ctx.game_communication_path, "Checked_Locations.cfg"), 'w') as f:
+                    f.write(str(list(ctx.locations_checked)))
+            except Exception:
+                pass
+            message = [{"cmd": 'LocationChecks', "locations": sending}]
+            await ctx.send_msgs(message)
         if not ctx.finished_game and victory:
             await ctx.send_msgs([{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}])
             ctx.finished_game = True

--- a/worlds/lol/Client.py
+++ b/worlds/lol/Client.py
@@ -85,6 +85,37 @@ class LOLContext(SuperContext):
                 if file.find("obtain") <= -1:
                     os.remove(root+"/"+file)
 
+    def _clear_victory_marker(self):
+        try:
+            os.remove(os.path.join(self.game_communication_path, "victory"))
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass
+
+    def _write_hinted_locations(self):
+        key = f"_read_hints_{self.team}_{self.slot}"
+        hinted_locations = set()
+        for hint in self.stored_data.get(key, []):
+            if isinstance(hint, dict):
+                if hint.get("found", False):
+                    continue
+                location = hint.get("location")
+            else:
+                location = getattr(hint, "location", None)
+                if getattr(hint, "found", False):
+                    continue
+            try:
+                if location is not None:
+                    hinted_locations.add(int(location))
+            except (TypeError, ValueError):
+                pass
+        try:
+            with open(os.path.join(self.game_communication_path, "Hinted_Locations.cfg"), 'w') as f:
+                f.write(str(sorted(hinted_locations)))
+        except Exception:
+            pass
+
     async def server_auth(self, password_requested: bool = False):
         if password_requested and not self.password:
             await super(LOLContext, self).server_auth(password_requested)
@@ -113,7 +144,17 @@ class LOLContext(SuperContext):
                     os.remove(root+"/"+file)
 
     def on_package(self, cmd: str, args: dict):
+        slot_changed = False
+        if cmd == "Connected":
+            previous_identity = (self.team, self.slot)
+            new_identity = (args.get("team"), args.get("slot"))
+            slot_changed = previous_identity != new_identity and previous_identity != (None, None)
+            if slot_changed:
+                self.finished_game = False
+                self._clear_victory_marker()
         super().on_package(cmd, args)
+        if cmd in {"Connected", "Retrieved", "SetReply"}:
+            self._write_hinted_locations()
         if cmd in {"Connected"}:
             if not os.path.exists(self.game_communication_path):
                 os.makedirs(self.game_communication_path)

--- a/worlds/lol/Connector.py
+++ b/worlds/lol/Connector.py
@@ -15,16 +15,19 @@ for champion in list(champion_data.keys()):
 
 ###SET GLOBAL VARIABLES###
 url = "https://127.0.0.1:2999/liveclientdata/allgamedata"
+GAME_WIN_LOCATION_CODE = 566900001
 unlocked_champion_ids = []
 total_lp_gained = 0
 in_match = False
+tracked_teammates = set()
 game_values = {
     "required_assists": 0,
     "required_cs"     : 0,
     "required_kills"  : 0,
     "required_lp"     : 0,
     "required_vs"     : 0,
-    "current_lp"      : 0
+    "current_lp"      : 0,
+    "starting_champions": 0
 }
 
 ###SET UP GAME COMMUNICATION PATH###
@@ -51,10 +54,11 @@ def get_items(game_values):
             if file.startswith("AP"):
                 with open(os.path.join(game_communication_path, file), 'r') as f:
                     item_id = int(f.readline())
-                    if item_id % 565000000 == 0:
+                    decoded_item = item_id - 565000000
+                    if decoded_item == 0:
                         game_values["current_lp"] = game_values["current_lp"] + 1
-                    else:
-                        unlocked_champion_ids.append(item_id % 565000000)
+                    elif decoded_item in champions:
+                        unlocked_champion_ids.append(decoded_item)
                     f.close()
 
 def read_cfg(game_values):
@@ -84,6 +88,11 @@ def read_cfg(game_values):
                 game_values["required_vs"] = int(f.readline())
         else:
             game_values["required_vs"] = 0
+        if "Starting_Champion_Count.cfg" in files:
+            with open(os.path.join(game_communication_path, "Starting_Champion_Count.cfg"), 'r') as f:
+                game_values["starting_champions"] = max(0, int(f.readline()))
+        else:
+            game_values["starting_champions"] = 0
 
 def display_champion_list(window):
     champion_table_rows = []
@@ -101,14 +110,25 @@ def display_values(window, game_values):
     value_table_rows.append(['Current LP:'           , str(game_values["current_lp"])])
     window["Values Table"].update(values=value_table_rows)
 
-def send_starting_champion_check():
-    for i in range(6):
-        with open(os.path.join(game_communication_path, "send56600000" + str(i)), 'w') as f:
+def send_starting_champion_check(game_values):
+    for i in range(1, game_values["starting_champions"] + 1):
+        with open(os.path.join(game_communication_path, f"send{566000000 + i}"), 'w') as f:
             f.close()
 
 def check_lp_for_victory(game_values):
     if game_values["current_lp"] >= game_values["required_lp"] and game_values["required_lp"] != 0:
         with open(os.path.join(game_communication_path, "victory"), 'w') as f:
+            f.close()
+
+def won_game(game_data):
+    for event in game_data["events"]["Events"]:
+        if event.get("EventName") == "GameEnd" and event.get("Result") == "Win":
+            return True
+    return False
+
+def send_game_win_location(game_data):
+    if won_game(game_data):
+        with open(os.path.join(game_communication_path, f"send{GAME_WIN_LOCATION_CODE}"), 'w') as f:
             f.close()
 
 def get_player_name(game_data):
@@ -123,6 +143,36 @@ def get_champion_id(champion_name):
     for champion_id in champions:
         if champions[champion_id]["name"] == champion_name:
             return champion_id
+
+def get_player_data(game_data, player_name):
+    for player in game_data["allPlayers"]:
+        if player["riotIdGameName"] == player_name:
+            return player
+    return None
+
+def get_available_teammates(game_data):
+    player_name = get_player_name(game_data)
+    player_data = get_player_data(game_data, player_name)
+    if player_data is None:
+        return []
+
+    player_team = player_data.get("team")
+    teammate_names = []
+    for player in game_data["allPlayers"]:
+        if player.get("team") == player_team and player["riotIdGameName"] != player_name:
+            teammate_names.append(player["riotIdGameName"])
+    return sorted(teammate_names)
+
+def update_teammate_selector(window, teammate_names):
+    valid_teammates = sorted(tracked_teammates.intersection(teammate_names))
+    set_to_index = [teammate_names.index(teammate_name) for teammate_name in valid_teammates]
+    window["Tracked Teammates List"].update(values=teammate_names, set_to_index=set_to_index)
+
+def get_tracked_players(game_data):
+    player_name = get_player_name(game_data)
+    teammate_names = set(get_available_teammates(game_data))
+    selected_teammates = sorted(tracked_teammates.intersection(teammate_names))
+    return [player_name] + selected_teammates
 
 def took_tower(game_data, player_name):
     for event in game_data["events"]["Events"]:
@@ -208,11 +258,16 @@ def kills_above(game_data, player_name, score_target):
 def assists_above(game_data, player_name, score_target):
     return player_assists(game_data, player_name) >= score_target and score_target > 0
 
-def get_objectives_complete(game_data, game_values):
+def get_objectives_complete_for_player(game_data, game_values, player_name):
     objectives_complete = []
-    player_name = get_player_name(game_data)
     champion_name = get_champion_name(game_data, player_name)
+    if champion_name is None:
+        return objectives_complete, None
+
     champion_id = get_champion_id(champion_name)
+    if champion_id is None:
+        return objectives_complete, None
+
     if champion_id in unlocked_champion_ids:
         if assisted_epic_monster(game_data, player_name, "Dragon"):
             objectives_complete.append(1)
@@ -232,7 +287,13 @@ def get_objectives_complete(game_data, game_values):
             objectives_complete.append(8)
         if creep_score_above(game_data, player_name, game_values["required_cs"]):
             objectives_complete.append(9)
-    send_locations(objectives_complete, champion_id)
+    return objectives_complete, champion_id
+
+def get_objectives_complete(game_data, game_values):
+    for player_name in get_tracked_players(game_data):
+        objectives_complete, champion_id = get_objectives_complete_for_player(game_data, game_values, player_name)
+        if champion_id is not None:
+            send_locations(objectives_complete, champion_id)
 
 def send_locations(objectives_complete, champion_id):
     for objective_id in objectives_complete:
@@ -257,6 +318,16 @@ layout = [  [
                     [sg.Table(
                         [
                         ], headings = ["Value Type", "Value Amount"], key = "Values Table")]
+               ]),
+                sg.Column(
+                [
+                    [sg.Text("Tracked Teammates")],
+                    [sg.Listbox(
+                        values = [],
+                        select_mode = sg.LISTBOX_SELECT_MODE_MULTIPLE,
+                        size = (24, 6),
+                        enable_events = True,
+                        key = "Tracked Teammates List")]
                ])
             ]
         ]
@@ -269,19 +340,24 @@ while True:
         break
     if event == 'Check for Match Button':
         in_match = True
+    if event == "Tracked Teammates List":
+        tracked_teammates = set(values["Tracked Teammates List"])
     check_lp_for_victory(game_values)
     get_items(game_values)
     read_cfg(game_values)
     display_champion_list(window)
     display_values(window, game_values)
-    send_starting_champion_check()
+    send_starting_champion_check(game_values)
     if in_match:
         game_data = get_game_data()
     if game_data is None:
         window["In Match Text"].update("In Match: No Match Found")
+        update_teammate_selector(window, [])
         in_match = False
     else:
         window["In Match Text"].update("In Match: In Match")
+        update_teammate_selector(window, get_available_teammates(game_data))
         get_objectives_complete(game_data, game_values)
+        send_game_win_location(game_data)
 
 window.close()

--- a/worlds/lol/Connector.py
+++ b/worlds/lol/Connector.py
@@ -18,13 +18,15 @@ url = "https://127.0.0.1:2999/liveclientdata/allgamedata"
 unlocked_champion_ids = []
 total_lp_gained = 0
 in_match = False
+tracked_teammates = set()
 game_values = {
     "required_assists": 0,
     "required_cs"     : 0,
     "required_kills"  : 0,
     "required_lp"     : 0,
     "required_vs"     : 0,
-    "current_lp"      : 0
+    "current_lp"      : 0,
+    "starting_champions": 0
 }
 
 ###SET UP GAME COMMUNICATION PATH###
@@ -51,10 +53,11 @@ def get_items(game_values):
             if file.startswith("AP"):
                 with open(os.path.join(game_communication_path, file), 'r') as f:
                     item_id = int(f.readline())
-                    if item_id % 565000000 == 0:
+                    decoded_item = item_id - 565000000
+                    if decoded_item == 0:
                         game_values["current_lp"] = game_values["current_lp"] + 1
-                    else:
-                        unlocked_champion_ids.append(item_id % 565000000)
+                    elif decoded_item in champions:
+                        unlocked_champion_ids.append(decoded_item)
                     f.close()
 
 def read_cfg(game_values):
@@ -84,6 +87,11 @@ def read_cfg(game_values):
                 game_values["required_vs"] = int(f.readline())
         else:
             game_values["required_vs"] = 0
+        if "Starting_Champion_Count.cfg" in files:
+            with open(os.path.join(game_communication_path, "Starting_Champion_Count.cfg"), 'r') as f:
+                game_values["starting_champions"] = max(0, int(f.readline()))
+        else:
+            game_values["starting_champions"] = 0
 
 def display_champion_list(window):
     champion_table_rows = []
@@ -101,15 +109,21 @@ def display_values(window, game_values):
     value_table_rows.append(['Current LP:'           , str(game_values["current_lp"])])
     window["Values Table"].update(values=value_table_rows)
 
-def send_starting_champion_check():
-    for i in range(6):
-        with open(os.path.join(game_communication_path, "send56600000" + str(i)), 'w') as f:
+def send_starting_champion_check(game_values):
+    for i in range(1, game_values["starting_champions"] + 1):
+        with open(os.path.join(game_communication_path, f"send{566000000 + i}"), 'w') as f:
             f.close()
 
 def check_lp_for_victory(game_values):
     if game_values["current_lp"] >= game_values["required_lp"] and game_values["required_lp"] != 0:
         with open(os.path.join(game_communication_path, "victory"), 'w') as f:
             f.close()
+
+def won_game(game_data):
+    for event in game_data["events"]["Events"]:
+        if event.get("EventName") == "GameEnd" and event.get("Result") == "Win":
+            return True
+    return False
 
 def get_player_name(game_data):
     return game_data["activePlayer"]["riotIdGameName"]
@@ -123,6 +137,36 @@ def get_champion_id(champion_name):
     for champion_id in champions:
         if champions[champion_id]["name"] == champion_name:
             return champion_id
+
+def get_player_data(game_data, player_name):
+    for player in game_data["allPlayers"]:
+        if player["riotIdGameName"] == player_name:
+            return player
+    return None
+
+def get_available_teammates(game_data):
+    player_name = get_player_name(game_data)
+    player_data = get_player_data(game_data, player_name)
+    if player_data is None:
+        return []
+
+    player_team = player_data.get("team")
+    teammate_names = []
+    for player in game_data["allPlayers"]:
+        if player.get("team") == player_team and player["riotIdGameName"] != player_name:
+            teammate_names.append(player["riotIdGameName"])
+    return sorted(teammate_names)
+
+def update_teammate_selector(window, teammate_names):
+    valid_teammates = sorted(tracked_teammates.intersection(teammate_names))
+    set_to_index = [teammate_names.index(teammate_name) for teammate_name in valid_teammates]
+    window["Tracked Teammates List"].update(values=teammate_names, set_to_index=set_to_index)
+
+def get_tracked_players(game_data):
+    player_name = get_player_name(game_data)
+    teammate_names = set(get_available_teammates(game_data))
+    selected_teammates = sorted(tracked_teammates.intersection(teammate_names))
+    return [player_name] + selected_teammates
 
 def took_tower(game_data, player_name):
     for event in game_data["events"]["Events"]:
@@ -208,11 +252,16 @@ def kills_above(game_data, player_name, score_target):
 def assists_above(game_data, player_name, score_target):
     return player_assists(game_data, player_name) >= score_target and score_target > 0
 
-def get_objectives_complete(game_data, game_values):
+def get_objectives_complete_for_player(game_data, game_values, player_name):
     objectives_complete = []
-    player_name = get_player_name(game_data)
     champion_name = get_champion_name(game_data, player_name)
+    if champion_name is None:
+        return objectives_complete, None
+
     champion_id = get_champion_id(champion_name)
+    if champion_id is None:
+        return objectives_complete, None
+
     if champion_id in unlocked_champion_ids:
         if assisted_epic_monster(game_data, player_name, "Dragon"):
             objectives_complete.append(1)
@@ -224,6 +273,8 @@ def get_objectives_complete(game_data, game_values):
             objectives_complete.append(4)
         if assisted_inhibitor(game_data, player_name):
             objectives_complete.append(5)
+        if won_game(game_data):
+            objectives_complete.append(10)
         if assists_above(game_data, player_name, game_values["required_assists"]):
             objectives_complete.append(6)
         if vision_score_above(game_data, player_name, game_values["required_vs"]):
@@ -232,7 +283,13 @@ def get_objectives_complete(game_data, game_values):
             objectives_complete.append(8)
         if creep_score_above(game_data, player_name, game_values["required_cs"]):
             objectives_complete.append(9)
-    send_locations(objectives_complete, champion_id)
+    return objectives_complete, champion_id
+
+def get_objectives_complete(game_data, game_values):
+    for player_name in get_tracked_players(game_data):
+        objectives_complete, champion_id = get_objectives_complete_for_player(game_data, game_values, player_name)
+        if champion_id is not None:
+            send_locations(objectives_complete, champion_id)
 
 def send_locations(objectives_complete, champion_id):
     for objective_id in objectives_complete:
@@ -257,6 +314,16 @@ layout = [  [
                     [sg.Table(
                         [
                         ], headings = ["Value Type", "Value Amount"], key = "Values Table")]
+               ]),
+                sg.Column(
+                [
+                    [sg.Text("Tracked Teammates")],
+                    [sg.Listbox(
+                        values = [],
+                        select_mode = sg.LISTBOX_SELECT_MODE_MULTIPLE,
+                        size = (24, 6),
+                        enable_events = True,
+                        key = "Tracked Teammates List")]
                ])
             ]
         ]
@@ -269,19 +336,23 @@ while True:
         break
     if event == 'Check for Match Button':
         in_match = True
+    if event == "Tracked Teammates List":
+        tracked_teammates = set(values["Tracked Teammates List"])
     check_lp_for_victory(game_values)
     get_items(game_values)
     read_cfg(game_values)
     display_champion_list(window)
     display_values(window, game_values)
-    send_starting_champion_check()
+    send_starting_champion_check(game_values)
     if in_match:
         game_data = get_game_data()
     if game_data is None:
         window["In Match Text"].update("In Match: No Match Found")
+        update_teammate_selector(window, [])
         in_match = False
     else:
         window["In Match Text"].update("In Match: In Match")
+        update_teammate_selector(window, get_available_teammates(game_data))
         get_objectives_complete(game_data, game_values)
 
 window.close()

--- a/worlds/lol/Connector.py
+++ b/worlds/lol/Connector.py
@@ -4,6 +4,7 @@ import requests
 import os
 import ast
 import sys
+import time
 
 ###GET VERSION###
 def _get_world_version() -> str:
@@ -57,7 +58,10 @@ if not os.path.exists(game_communication_path):
 ###DEFINE FUNCTIONS###
 def get_game_data():
     try:
-        return requests.get(url, verify=False).json()
+        data = requests.get(url, verify=False).json()
+        if "activePlayer" not in data or "allPlayers" not in data:
+            return None
+        return data
     except:
         return None
 
@@ -493,7 +497,7 @@ layout = [  [
         ]
 
 window = sg.Window(_WINDOW_TITLE, layout)
-window.metadata = {"champion_sort": "name", "selected_champion_id": None}
+window.metadata = {"champion_sort": "name", "selected_champion_id": None, "game_connected": False}
 while True:
     game_data = None
     event, values = window.read(timeout=2000)
@@ -501,6 +505,7 @@ while True:
         break
     if event == 'Check for Match Button':
         in_match = True
+        window.metadata["game_connected"] = False
     if isinstance(event, tuple) and len(event) == 3 and event[0] == "Champions Unlocked Table" and event[1] == "+CLICKED+":
         cell = event[2]
         # cell may be an int or a (row, col) tuple depending on PySimpleGUI version/events
@@ -547,11 +552,26 @@ while True:
     send_starting_champion_check(game_values)
     if in_match:
         game_data = get_game_data()
+        if game_data is None and window.metadata.get("game_connected"):
+            # Was previously connected — game may have just ended. Retry quickly
+            # to capture the final state before the API shuts down.
+            for _ in range(5):
+                time.sleep(0.4)
+                game_data = get_game_data()
+                if game_data is not None:
+                    break
     if game_data is None:
-        window["In Match Text"].update("In Match: No Match Found")
-        update_teammate_selector(window, [])
-        in_match = False
+        if in_match and not window.metadata.get("game_connected"):
+            # Still waiting for the game to finish loading
+            window["In Match Text"].update("In Match: Waiting for game...")
+            update_teammate_selector(window, [])
+        else:
+            window["In Match Text"].update("In Match: No Match Found")
+            update_teammate_selector(window, [])
+            in_match = False
+            window.metadata["game_connected"] = False
     else:
+        window.metadata["game_connected"] = True
         window["In Match Text"].update("In Match: In Match")
         update_teammate_selector(window, get_available_teammates(game_data))
         get_objectives_complete(game_data, game_values)

--- a/worlds/lol/Connector.py
+++ b/worlds/lol/Connector.py
@@ -2,6 +2,20 @@ import PySimpleGUI as sg
 import json
 import requests
 import os
+import ast
+import sys
+
+###GET VERSION###
+def _get_world_version() -> str:
+    try:
+        base = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__)))
+        with open(os.path.join(base, 'archipelago.json'), 'r') as f:
+            return json.load(f).get('world_version', '')
+    except Exception:
+        return ''
+
+_WORLD_VERSION = _get_world_version()
+_WINDOW_TITLE = f"LOL AP v{_WORLD_VERSION}" if _WORLD_VERSION else "LOL AP"
 
 ###GET CHAMPION DATA###
 versions_url = "https://ddragon.leagueoflegends.com/api/versions.json"
@@ -26,7 +40,9 @@ game_values = {
     "required_lp"     : 0,
     "required_vs"     : 0,
     "current_lp"      : 0,
-    "starting_champions": 0
+    "starting_champions": 0,
+    "enabled_checks"  : None,
+    "support_special_treatment": True
 }
 
 ###SET UP GAME COMMUNICATION PATH###
@@ -92,22 +108,154 @@ def read_cfg(game_values):
                 game_values["starting_champions"] = max(0, int(f.readline()))
         else:
             game_values["starting_champions"] = 0
+        if "Enabled_Checks.cfg" in files:
+            with open(os.path.join(game_communication_path, "Enabled_Checks.cfg"), 'r') as f:
+                game_values["enabled_checks"] = ast.literal_eval(f.read())
+        else:
+            game_values["enabled_checks"] = None
+        if "Support_Special_Treatment.cfg" in files:
+            with open(os.path.join(game_communication_path, "Support_Special_Treatment.cfg"), 'r') as f:
+                game_values["support_special_treatment"] = bool(int(f.read().strip()))
+        else:
+            game_values["support_special_treatment"] = True
 
 def display_champion_list(window):
+    # Try to read active locations and mapping from the client slot data
+    active_locations = None
+    active_location_ids = None
+    checked_location_ids = None
+    try:
+        path = os.path.join(game_communication_path, "Active_Locations.cfg")
+        if os.path.exists(path):
+            with open(path, 'r') as f:
+                active_locations = ast.literal_eval(f.read())
+    except Exception:
+        active_locations = None
+
+    try:
+        path = os.path.join(game_communication_path, "Active_Location_IDs.cfg")
+        if os.path.exists(path):
+            with open(path, 'r') as f:
+                active_location_ids = ast.literal_eval(f.read())
+    except Exception:
+        active_location_ids = None
+
+    try:
+        path = os.path.join(game_communication_path, "Checked_Locations.cfg")
+        if os.path.exists(path):
+            with open(path, 'r') as f:
+                checked_location_ids = set(ast.literal_eval(f.read()))
+    except Exception:
+        checked_location_ids = None
+
+    # Build totals per champion from active_locations (names)
+    totals = {}
+    done = {}
+    if active_locations is not None:
+        for name in active_locations:
+            if name.startswith("Starting Champion"):
+                champ_key = "Starting"
+            else:
+                champ_key = name.split(" - ", 1)[0]
+            totals[champ_key] = totals.get(champ_key, 0) + 1
+            done.setdefault(champ_key, 0)
+
+    # If we have id->name mapping, use checked ids to count done per champion
+    if active_location_ids is not None and checked_location_ids is not None:
+        # invert mapping to id -> name
+        id_to_name = {int(v): k for k, v in active_location_ids.items() if v is not None}
+        for lid in checked_location_ids:
+            name = id_to_name.get(int(lid))
+            if name:
+                if name.startswith("Starting Champion"):
+                    champ_key = "Starting"
+                else:
+                    champ_key = name.split(" - ", 1)[0]
+                done[champ_key] = done.get(champ_key, 0) + 1
+
+    # Fallback: if mappings aren't available, fall back to previous per-champion send file counting
     champion_table_rows = []
-    for champion_id in unlocked_champion_ids:
-        champion_table_rows.append([champions[champion_id]["name"], champion_id])
+    if active_locations is None or active_location_ids is None or checked_location_ids is None:
+        def count_remaining(champion_id: int) -> int:
+            prefix = "send" + str(566000000 + (champion_id * 100))
+            cnt = 0
+            try:
+                for filename in os.listdir(game_communication_path):
+                    if filename.startswith(prefix):
+                        cnt += 1
+            except Exception:
+                cnt = 0
+            total_objectives = 10
+            return max(0, total_objectives - cnt)
+
+        for champion_id in unlocked_champion_ids:
+            remaining = count_remaining(champion_id)
+            champion_table_rows.append([champions[champion_id]["name"], str(remaining)])
+    else:
+        for champion_id in unlocked_champion_ids:
+            name = champions[champion_id]["name"]
+            total = totals.get(name, 0)
+            done_count = done.get(name, 0)
+            remaining = max(0, total - done_count)
+            champion_table_rows.append([name, str(remaining)])
+
+    # honor current sort preference if set on the window object
+    sort_pref = window.metadata.get("champion_sort", "name") if hasattr(window, "metadata") else "name"
+    reverse = False
+    if sort_pref.endswith("_desc"):
+        reverse = True
+        sort_pref = sort_pref.replace("_desc", "")
+    if sort_pref == "name":
+        champion_table_rows.sort(key=lambda r: r[0], reverse=reverse)
+    elif sort_pref == "remaining":
+        champion_table_rows.sort(key=lambda r: int(r[1]), reverse=reverse)
+
+    # Cache for remaining-checks panel
+    window.metadata["active_location_ids"] = active_location_ids
+    window.metadata["checked_location_ids"] = checked_location_ids
+
+    # Auto-select first champion if none selected yet
+    if window.metadata.get("selected_champion_id") is None and champion_table_rows:
+        window.metadata["selected_champion_id"] = get_champion_id(champion_table_rows[0][0])
+
     window["Champions Unlocked Table"].update(values=champion_table_rows)
 
 def display_values(window, game_values):
-    value_table_rows = []
-    value_table_rows.append(['Required Kills:'       , str(game_values["required_kills"])])
-    value_table_rows.append(['Required Assists:'     , str(game_values["required_assists"])])
-    value_table_rows.append(['Required CS:'          , str(game_values["required_cs"])])
-    value_table_rows.append(['Required VS:'          , str(game_values["required_vs"])])
-    value_table_rows.append(['Required LP:'          , str(game_values["required_lp"])])
-    value_table_rows.append(['Current LP:'           , str(game_values["current_lp"])])
-    window["Values Table"].update(values=value_table_rows)
+    selected_champion_id = window.metadata.get("selected_champion_id") if hasattr(window, "metadata") else None
+    active_location_ids  = window.metadata.get("active_location_ids")  if hasattr(window, "metadata") else None
+    checked_location_ids = window.metadata.get("checked_location_ids") if hasattr(window, "metadata") else None
+
+    if selected_champion_id is None or selected_champion_id not in champions:
+        window["Values Table"].update(values=[])
+        return
+
+    champion_name = champions[selected_champion_id]["name"]
+
+    if active_location_ids is None or checked_location_ids is None:
+        window["Values Table"].update(values=[])
+        return
+
+    checked_ids = {int(x) for x in checked_location_ids}
+    prefix = champion_name + " - "
+
+    # Map the fixed "X" placeholder to the real required number
+    x_substitutions = {
+        "Get X Kills":        f"Get {game_values['required_kills']} Kills",
+        "Get X Assists":      f"Get {game_values['required_assists']} Assists",
+        "Get X Creep Score":  f"Get {game_values['required_cs']} Creep Score",
+        "Get X Ward Score":   f"Get {game_values['required_vs']} Ward Score",
+    }
+
+    rows = []
+    for loc_name, loc_id in active_location_ids.items():
+        if not loc_name.startswith(prefix):
+            continue
+        if loc_id is not None and int(loc_id) in checked_ids:
+            continue
+        suffix = loc_name[len(prefix):]
+        rows.append([x_substitutions.get(suffix, suffix)])
+
+    window["Values Table"].update(values=rows)
 
 def send_starting_champion_check(game_values):
     for i in range(1, game_values["starting_champions"] + 1):
@@ -263,25 +411,39 @@ def get_objectives_complete_for_player(game_data, game_values, player_name):
         return objectives_complete, None
 
     if champion_id in unlocked_champion_ids:
-        if assisted_epic_monster(game_data, player_name, "Dragon"):
+        is_support = "Support" in champions[champion_id]["tags"]
+        enabled = set(game_values.get("enabled_checks") or [])
+        sst = game_values.get("support_special_treatment", True)
+
+        def check_enabled(check_name):
+            if enabled and check_name not in enabled:
+                return False
+            if sst:
+                if check_name == "Vision Score" and not is_support:
+                    return False
+                if check_name in ("Kills", "Creep Score") and is_support:
+                    return False
+            return True
+
+        if check_enabled("Dragon") and assisted_epic_monster(game_data, player_name, "Dragon"):
             objectives_complete.append(1)
-        if assisted_epic_monster(game_data, player_name, "Herald") or assisted_epic_monster(game_data, player_name, "Horde"):
+        if check_enabled("Herald") and (assisted_epic_monster(game_data, player_name, "Herald") or assisted_epic_monster(game_data, player_name, "Horde")):
             objectives_complete.append(2)
-        if assisted_epic_monster(game_data, player_name, "Baron"):
+        if check_enabled("Baron") and assisted_epic_monster(game_data, player_name, "Baron"):
             objectives_complete.append(3)
-        if assisted_tower(game_data, player_name):
+        if check_enabled("Tower") and assisted_tower(game_data, player_name):
             objectives_complete.append(4)
-        if assisted_inhibitor(game_data, player_name):
+        if check_enabled("Inhibitor") and assisted_inhibitor(game_data, player_name):
             objectives_complete.append(5)
-        if won_game(game_data):
+        if check_enabled("Game Win") and won_game(game_data):
             objectives_complete.append(10)
-        if assists_above(game_data, player_name, game_values["required_assists"]):
+        if check_enabled("Assists") and assists_above(game_data, player_name, game_values["required_assists"]):
             objectives_complete.append(6)
-        if vision_score_above(game_data, player_name, game_values["required_vs"]):
+        if check_enabled("Vision Score") and vision_score_above(game_data, player_name, game_values["required_vs"]):
             objectives_complete.append(7)
-        if kills_above(game_data, player_name, game_values["required_kills"]):
+        if check_enabled("Kills") and kills_above(game_data, player_name, game_values["required_kills"]):
             objectives_complete.append(8)
-        if creep_score_above(game_data, player_name, game_values["required_cs"]):
+        if check_enabled("Creep Score") and creep_score_above(game_data, player_name, game_values["required_cs"]):
             objectives_complete.append(9)
     return objectives_complete, champion_id
 
@@ -306,14 +468,16 @@ layout = [  [
                 [   [sg.Text("Champions Unlocked")],
                     [sg.Table(
                         [
-                        ], headings = ["Champion Name", "Champion ID"], key = "Champions Unlocked Table")]
+                        ], headings = ["Champion Name", "Remaining"], key = "Champions Unlocked Table",
+                        enable_click_events = True)]
                 ]),
                 sg.Column(
                 [
-                    [sg.Text("Required Values")],
+                    [sg.Text("Remaining Checks")],
                     [sg.Table(
                         [
-                        ], headings = ["Value Type", "Value Amount"], key = "Values Table")]
+                        ], headings = ["Check"], key = "Values Table",
+                        col_widths = [24], auto_size_columns = False)]
                ]),
                 sg.Column(
                 [
@@ -328,7 +492,8 @@ layout = [  [
             ]
         ]
 
-window = sg.Window('LOL AP', layout)
+window = sg.Window(_WINDOW_TITLE, layout)
+window.metadata = {"champion_sort": "name", "selected_champion_id": None}
 while True:
     game_data = None
     event, values = window.read(timeout=2000)
@@ -336,6 +501,42 @@ while True:
         break
     if event == 'Check for Match Button':
         in_match = True
+    if isinstance(event, tuple) and len(event) == 3 and event[0] == "Champions Unlocked Table" and event[1] == "+CLICKED+":
+        cell = event[2]
+        # cell may be an int or a (row, col) tuple depending on PySimpleGUI version/events
+        row_index = None
+        col = None
+        if isinstance(cell, (list, tuple)) and len(cell) >= 1:
+            row_index = cell[0]
+            if len(cell) >= 2:
+                col = cell[1]
+        else:
+            try:
+                row_index = int(cell)
+            except Exception:
+                row_index = None
+
+        if row_index == -1:
+            # header clicked -> sort by column if we know the column index
+            if col is None:
+                continue
+            prev = window.metadata.get("champion_sort", "name")
+            sort_keys = ["name", "remaining"]
+            if col < len(sort_keys):
+                new_sort = sort_keys[col]
+                if prev == new_sort:
+                    window.metadata["champion_sort"] = new_sort + "_desc"
+                elif prev == new_sort + "_desc":
+                    window.metadata["champion_sort"] = new_sort
+                else:
+                    window.metadata["champion_sort"] = new_sort
+        else:
+            # row clicked -> select champion if index valid
+            if row_index is None:
+                continue
+            table_data = window["Champions Unlocked Table"].Values
+            if table_data and 0 <= row_index < len(table_data):
+                window.metadata["selected_champion_id"] = get_champion_id(table_data[row_index][0])
     if event == "Tracked Teammates List":
         tracked_teammates = set(values["Tracked Teammates List"])
     check_lp_for_victory(game_values)

--- a/worlds/lol/Connector.py
+++ b/worlds/lol/Connector.py
@@ -4,7 +4,7 @@ import requests
 import os
 import ast
 import sys
-import time
+from concurrent.futures import ThreadPoolExecutor
 
 ###GET VERSION###
 def _get_world_version() -> str:
@@ -31,7 +31,6 @@ for champion in list(champion_data.keys()):
 ###SET GLOBAL VARIABLES###
 url = "https://127.0.0.1:2999/liveclientdata/allgamedata"
 unlocked_champion_ids = []
-total_lp_gained = 0
 in_match = False
 tracked_teammates = set()
 game_values = {
@@ -57,71 +56,97 @@ if not os.path.exists(game_communication_path):
 
 ###DEFINE FUNCTIONS###
 def get_game_data():
+    """Returns (status, data) where status is one of:
+      'api_down'     - League client not running / not in a game
+      'loading'      - API up but game hasn't started yet (no events)
+      'in_game'      - Active game in progress
+      'game_over'    - GameEnd event received
+    """
     try:
-        data = requests.get(url, verify=False).json()
+        data = requests.get(url, verify=False, timeout=1).json()
         if "activePlayer" not in data or "allPlayers" not in data:
-            return None
-        return data
+            return "api_down", None
+        events = data.get("events", {}).get("Events", [])
+        if not events:
+            return "loading", data
+        for event in events:
+            if event.get("EventName") == "GameEnd":
+                return "game_over", data
+        return "in_game", data
     except:
-        return None
+        return "api_down", None
 
 def get_items(game_values):
     game_values["current_lp"] = 0
     unlocked_champion_ids.clear()
-    for root, dirs, files in os.walk(game_communication_path):
-        for file in files:
-            if file.startswith("AP"):
-                with open(os.path.join(game_communication_path, file), 'r') as f:
-                    item_id = int(f.readline())
-                    decoded_item = item_id - 565000000
-                    if decoded_item == 0:
-                        game_values["current_lp"] = game_values["current_lp"] + 1
-                    elif decoded_item in champions:
-                        unlocked_champion_ids.append(decoded_item)
-                    f.close()
+    for file in os.listdir(game_communication_path):
+        if file.startswith("AP"):
+            with open(os.path.join(game_communication_path, file), 'r') as f:
+                item_id = int(f.readline())
+                decoded_item = item_id - 565000000
+                if decoded_item == 0:
+                    game_values["current_lp"] = game_values["current_lp"] + 1
+                elif decoded_item in champions:
+                    unlocked_champion_ids.append(decoded_item)
 
 def read_cfg(game_values):
-    for root, dirs, files in os.walk(game_communication_path):
-        if "Required_Assists.cfg" in files:
-            with open(os.path.join(game_communication_path, "Required_Assists.cfg"), 'r') as f:
-                game_values["required_assists"] = int(f.readline())
-        else:
-            game_values["required_assists"] = 0
-        if "Required_CS.cfg" in files:
-            with open(os.path.join(game_communication_path, "Required_CS.cfg"), 'r') as f:
-                game_values["required_cs"] = int(f.readline())
-        else:
-            game_values["required_cs"] = 0
-        if "Required_Kills.cfg" in files:
-            with open(os.path.join(game_communication_path, "Required_Kills.cfg"), 'r') as f:
-                game_values["required_kills"] = int(f.readline())
-        else:
-            game_values["required_kills"] = 0
-        if "Required_LP.cfg" in files:
-            with open(os.path.join(game_communication_path, "Required_LP.cfg"), 'r') as f:
-                game_values["required_lp"] = int(f.readline())
-        else:
-            game_values["required_lp"] = 0
-        if "Required_VS.cfg" in files:
-            with open(os.path.join(game_communication_path, "Required_VS.cfg"), 'r') as f:
-                game_values["required_vs"] = int(f.readline())
-        else:
-            game_values["required_vs"] = 0
-        if "Starting_Champion_Count.cfg" in files:
-            with open(os.path.join(game_communication_path, "Starting_Champion_Count.cfg"), 'r') as f:
-                game_values["starting_champions"] = max(0, int(f.readline()))
-        else:
-            game_values["starting_champions"] = 0
-        if "Enabled_Checks.cfg" in files:
-            with open(os.path.join(game_communication_path, "Enabled_Checks.cfg"), 'r') as f:
-                game_values["enabled_checks"] = ast.literal_eval(f.read())
-        else:
-            game_values["enabled_checks"] = None
-        if "Support_Special_Treatment.cfg" in files:
-            with open(os.path.join(game_communication_path, "Support_Special_Treatment.cfg"), 'r') as f:
-                game_values["support_special_treatment"] = bool(int(f.read().strip()))
-        else:
-            game_values["support_special_treatment"] = True
+    files = os.listdir(game_communication_path)
+    if "Required_Assists.cfg" in files:
+        with open(os.path.join(game_communication_path, "Required_Assists.cfg"), 'r') as f:
+            game_values["required_assists"] = int(f.readline())
+    else:
+        game_values["required_assists"] = 0
+    if "Required_CS.cfg" in files:
+        with open(os.path.join(game_communication_path, "Required_CS.cfg"), 'r') as f:
+            game_values["required_cs"] = int(f.readline())
+    else:
+        game_values["required_cs"] = 0
+    if "Required_Kills.cfg" in files:
+        with open(os.path.join(game_communication_path, "Required_Kills.cfg"), 'r') as f:
+            game_values["required_kills"] = int(f.readline())
+    else:
+        game_values["required_kills"] = 0
+    if "Required_LP.cfg" in files:
+        with open(os.path.join(game_communication_path, "Required_LP.cfg"), 'r') as f:
+            game_values["required_lp"] = int(f.readline())
+    else:
+        game_values["required_lp"] = 0
+    if "Required_VS.cfg" in files:
+        with open(os.path.join(game_communication_path, "Required_VS.cfg"), 'r') as f:
+            game_values["required_vs"] = int(f.readline())
+    else:
+        game_values["required_vs"] = 0
+    if "Starting_Champion_Count.cfg" in files:
+        with open(os.path.join(game_communication_path, "Starting_Champion_Count.cfg"), 'r') as f:
+            game_values["starting_champions"] = max(0, int(f.readline()))
+    else:
+        game_values["starting_champions"] = 0
+    if "Enabled_Checks.cfg" in files:
+        with open(os.path.join(game_communication_path, "Enabled_Checks.cfg"), 'r') as f:
+            game_values["enabled_checks"] = ast.literal_eval(f.read())
+    else:
+        game_values["enabled_checks"] = None
+    if "Support_Special_Treatment.cfg" in files:
+        with open(os.path.join(game_communication_path, "Support_Special_Treatment.cfg"), 'r') as f:
+            game_values["support_special_treatment"] = bool(int(f.read().strip()))
+    else:
+        game_values["support_special_treatment"] = True
+
+def _champion_row_color(champion_id, window):
+    """Returns a background color for a champion row based on unlock/check state."""
+    if champion_id is None or champion_id not in unlocked_champion_ids:
+        return "#5C0000"  # dark red — locked
+    active_location_ids  = window.metadata.get("active_location_ids")  if hasattr(window, "metadata") else None
+    checked_location_ids = window.metadata.get("checked_location_ids") if hasattr(window, "metadata") else None
+    if active_location_ids is None or checked_location_ids is None:
+        return "#1A5C1A"  # green — unlocked, can't count yet
+    champ_name = champions[champion_id]["name"]
+    prefix = champ_name + " - "
+    checked_ids = {int(x) for x in checked_location_ids}
+    total = sum(1 for n in active_location_ids if n.startswith(prefix))
+    done  = sum(1 for n, lid in active_location_ids.items() if n.startswith(prefix) and lid is not None and int(lid) in checked_ids)
+    remaining = max(0, total - done)
+    return "#1A5C1A" if remaining > 0 else "#3A3A3A"  # green / grey
 
 def display_champion_list(window):
     # Try to read active locations and mapping from the client slot data
@@ -214,6 +239,10 @@ def display_champion_list(window):
     elif sort_pref == "remaining":
         champion_table_rows.sort(key=lambda r: int(r[1]), reverse=reverse)
 
+    # Filter out fully-completed champions if checkbox is on
+    if window["Hide Completed Checkbox"].get():
+        champion_table_rows = [r for r in champion_table_rows if int(r[1]) > 0]
+
     # Cache for remaining-checks panel
     window.metadata["active_location_ids"] = active_location_ids
     window.metadata["checked_location_ids"] = checked_location_ids
@@ -222,7 +251,14 @@ def display_champion_list(window):
     if window.metadata.get("selected_champion_id") is None and champion_table_rows:
         window.metadata["selected_champion_id"] = get_champion_id(champion_table_rows[0][0])
 
-    window["Champions Unlocked Table"].update(values=champion_table_rows)
+    window["Champions Unlocked Table"].update(
+        values=champion_table_rows,
+        row_colors=[(i, _champion_row_color(get_champion_id(r[0]), window))
+                    for i, r in enumerate(champion_table_rows)])
+
+    total_champions = sum(1 for k in totals if k != "Starting")
+    unlocked_count = len(unlocked_champion_ids)
+    window["Champion Count Text"].update(f"({unlocked_count} / {total_champions})")
 
 def display_values(window, game_values):
     selected_champion_id = window.metadata.get("selected_champion_id") if hasattr(window, "metadata") else None
@@ -263,13 +299,13 @@ def display_values(window, game_values):
 
 def send_starting_champion_check(game_values):
     for i in range(1, game_values["starting_champions"] + 1):
-        with open(os.path.join(game_communication_path, f"send{566000000 + i}"), 'w') as f:
-            f.close()
+        with open(os.path.join(game_communication_path, f"send{566000000 + i}"), 'w'):
+            pass
 
 def check_lp_for_victory(game_values):
     if game_values["current_lp"] >= game_values["required_lp"] and game_values["required_lp"] != 0:
-        with open(os.path.join(game_communication_path, "victory"), 'w') as f:
-            f.close()
+        with open(os.path.join(game_communication_path, "victory"), 'w'):
+            pass
 
 def won_game(game_data):
     for event in game_data["events"]["Events"]:
@@ -290,29 +326,27 @@ def get_champion_id(champion_name):
         if champions[champion_id]["name"] == champion_name:
             return champion_id
 
-def get_player_data(game_data, player_name):
-    for player in game_data["allPlayers"]:
-        if player["riotIdGameName"] == player_name:
-            return player
-    return None
-
 def get_available_teammates(game_data):
     player_name = get_player_name(game_data)
-    player_data = get_player_data(game_data, player_name)
-    if player_data is None:
+    player_team = None
+    for player in game_data["allPlayers"]:
+        if player["riotIdGameName"] == player_name:
+            player_team = player.get("team")
+            break
+    if player_team is None:
         return []
-
-    player_team = player_data.get("team")
     teammate_names = []
     for player in game_data["allPlayers"]:
         if player.get("team") == player_team and player["riotIdGameName"] != player_name:
             teammate_names.append(player["riotIdGameName"])
     return sorted(teammate_names)
 
-def update_teammate_selector(window, teammate_names):
-    valid_teammates = sorted(tracked_teammates.intersection(teammate_names))
-    set_to_index = [teammate_names.index(teammate_name) for teammate_name in valid_teammates]
-    window["Tracked Teammates List"].update(values=teammate_names, set_to_index=set_to_index)
+def update_teammate_selector(window, teammate_names, game_data=None):
+    display = []
+    for name in teammate_names:
+        tracking = "✓ " if name in tracked_teammates else "  "
+        display.append(tracking + name)
+    window["Tracked Teammates List"].update(values=display)
 
 def get_tracked_players(game_data):
     player_name = get_player_name(game_data)
@@ -320,21 +354,9 @@ def get_tracked_players(game_data):
     selected_teammates = sorted(tracked_teammates.intersection(teammate_names))
     return [player_name] + selected_teammates
 
-def took_tower(game_data, player_name):
-    for event in game_data["events"]["Events"]:
-        if event["EventName"] == "TurretKilled" and event["KillerName"] == player_name:
-            return True
-    return False
-
 def assisted_tower(game_data, player_name):
     for event in game_data["events"]["Events"]:
         if event["EventName"] == "TurretKilled" and (event["KillerName"] == player_name or player_name in event["Assisters"]):
-            return True
-    return False
-
-def took_inhibitor(game_data, player_name):
-    for event in game_data["events"]["Events"]:
-        if event["EventName"] == "InhibKilled" and event["KillerName"] == player_name:
             return True
     return False
 
@@ -344,27 +366,9 @@ def assisted_inhibitor(game_data, player_name):
             return True
     return False
 
-def took_epic_monster(game_data, player_name, monster_name):
-    for event in game_data["events"]["Events"]:
-        if event["EventName"] == monster_name + "Kill" and event["KillerName"] == player_name:
-            return True
-    return False
-
 def assisted_epic_monster(game_data, player_name, monster_name):
     for event in game_data["events"]["Events"]:
         if event["EventName"] == monster_name + "Kill" and (event["KillerName"] == player_name or player_name in event["Assisters"]):
-            return True
-    return False
-
-def stole_epic_monster(game_data, player_name, monster_name):
-    for event in game_data["events"]["Events"]:
-        if event["EventName"] == monster_name + "Kill" and (event["KillerName"] == player_name or player_name in event["Assisters"]) and str(event["Stolen"]) == "True":
-            return True
-    return False
-
-def assisted_kill(game_data, player_name):
-    for event in game_data["events"]["Events"]:
-        if event["EventName"] == "ChampionKill" and (event["KillerName"] == player_name or player_name in event["Assisters"]):
             return True
     return False
 
@@ -459,53 +463,153 @@ def get_objectives_complete(game_data, game_values):
 
 def send_locations(objectives_complete, champion_id):
     for objective_id in objectives_complete:
-        with open(os.path.join(game_communication_path, "send" + str(566000000 + (champion_id * 100) + objective_id)), 'w') as f:
-            f.close()
+        with open(os.path.join(game_communication_path, "send" + str(566000000 + (champion_id * 100) + objective_id)), 'w'):
+            pass
+
+###LCU / CHAMP SELECT###
+
+_lockfile_path_cache = None
+
+def _read_lockfile():
+    import subprocess
+    global _lockfile_path_cache
+    try:
+        if _lockfile_path_cache is None:
+            result = subprocess.run(
+                ["wmic", "process", "where", "name='LeagueClientUx.exe'", "get", "ExecutablePath", "/value"],
+                capture_output=True, text=True, timeout=3,
+                creationflags=subprocess.CREATE_NO_WINDOW
+            )
+            exe = ""
+            for line in result.stdout.splitlines():
+                if "ExecutablePath=" in line:
+                    exe = line.split("=", 1)[1].strip()
+                    break
+            if not exe:
+                return None, None
+            _lockfile_path_cache = os.path.join(os.path.dirname(exe), "lockfile")
+        with open(_lockfile_path_cache, 'r') as f:
+            parts = f.read().strip().split(':')
+        if len(parts) >= 4:
+            return parts[2].strip(), parts[3].strip()
+    except Exception:
+        _lockfile_path_cache = None
+    return None, None
+
+def get_champ_select_available_ids():
+    """Returns (lcu_ok, in_session, own_ids, teammate_ids, bench_ids).
+    lcu_ok=False means client not found. in_session=False means not in champ select."""
+    port, password = _read_lockfile()
+    if not port or not password:
+        return False, False, set(), set(), set()
+    try:
+        url = f"https://127.0.0.1:{port}/lol-champ-select/v1/session"
+        resp = requests.get(url, auth=("riot", password), verify=False, timeout=1)
+        if resp.status_code != 200:
+            return True, False, set(), set(), set()
+        session = resp.json()
+        own_ids = set()
+        teammate_ids = set()
+        bench_ids = set()
+        local_cell_id = session.get("localPlayerCellId")
+        for slot in session.get("myTeam", []):
+            cid = slot.get("championId") or slot.get("championPickIntent")
+            if not cid:
+                continue
+            if slot.get("cellId") == local_cell_id:
+                own_ids.add(cid)
+            else:
+                teammate_ids.add(cid)
+        for slot in session.get("benchChampions", []):
+            cid = slot.get("championId")
+            if cid:
+                bench_ids.add(cid)
+        return True, True, own_ids, teammate_ids, bench_ids
+    except Exception:
+        return True, False, set(), set(), set()
+
+def _champ_select_names_from_ids(ids, window):
+    """Given a set of champion IDs from champ select, return names of AP-unlocked
+    champions with remaining checks."""
+    active_location_ids  = window.metadata.get("active_location_ids")
+    checked_location_ids = window.metadata.get("checked_location_ids")
+    names = []
+    for cid in sorted(ids):
+        if cid not in unlocked_champion_ids:
+            continue
+        if cid not in champions:
+            continue
+        champ_name = champions[cid]["name"]
+        # check remaining
+        if active_location_ids is not None and checked_location_ids is not None:
+            prefix = champ_name + " - "
+            checked_ids = {int(x) for x in checked_location_ids}
+            total = sum(1 for n in active_location_ids if n.startswith(prefix))
+            done  = sum(1 for n, lid in active_location_ids.items() if n.startswith(prefix) and lid is not None and int(lid) in checked_ids)
+            if total - done <= 0:
+                continue
+        names.append(champ_name)
+    return names
 
 sg.theme('DarkAmber')
+_THEME_BG = "#2c2825"
 layout = [  [
                 sg.Text('In Match: No', justification = 'center', key = "In Match Text"),
-                sg.Button('Check for Match', key = "Check for Match Button", disabled_button_color = "blue")
+                sg.Button('Match Tracking: Off', key = "Check for Match Button", button_color=("white", "#5C0000")),
+                sg.Text('', key = "Champ Select Text", text_color="yellow")
             ],
             [   
                 sg.Column(
-                [   [sg.Text("Champions Unlocked")],
+                [   [sg.Text("Champions Unlocked"), sg.Text("", key="Champion Count Text"), sg.Checkbox("Hide Completed", key="Hide Completed Checkbox", default=False)],
                     [sg.Table(
-                        [
-                        ], headings = ["Champion Name", "Remaining"], key = "Champions Unlocked Table",
-                        enable_click_events = True)]
+                        [],
+                        headings=["Champion Name", "Remaining"],
+                        key="Champions Unlocked Table",
+                        enable_click_events=True)]
                 ]),
                 sg.Column(
                 [
                     [sg.Text("Remaining Checks")],
                     [sg.Table(
-                        [
-                        ], headings = ["Check"], key = "Values Table",
-                        col_widths = [24], auto_size_columns = False)]
+                        [],
+                        headings=["Check"],
+                        key="Values Table",
+                        col_widths=[24],
+                        auto_size_columns=False)]
                ]),
                 sg.Column(
                 [
                     [sg.Text("Tracked Teammates")],
                     [sg.Listbox(
-                        values = [],
-                        select_mode = sg.LISTBOX_SELECT_MODE_MULTIPLE,
-                        size = (24, 6),
-                        enable_events = True,
-                        key = "Tracked Teammates List")]
+                        [],
+                        size=(22, 5),
+                        enable_events=True,
+                        key="Tracked Teammates List",
+                        no_scrollbar=True)]
                ])
             ]
         ]
 
 window = sg.Window(_WINDOW_TITLE, layout)
-window.metadata = {"champion_sort": "name", "selected_champion_id": None, "game_connected": False}
+window.metadata = {"champion_sort": "name", "selected_champion_id": None, "game_connected": False, "lcu_status": None}
+
+_executor = ThreadPoolExecutor(max_workers=2)
+_game_future = None
+_lcu_future  = None
 while True:
     game_data = None
-    event, values = window.read(timeout=2000)
+    event, values = window.read(timeout=500)
     if event == sg.WIN_CLOSED:
         break
     if event == 'Check for Match Button':
-        in_match = True
+        in_match = not in_match
         window.metadata["game_connected"] = False
+        if in_match:
+            window["Check for Match Button"].update(text="Match Tracking: On", button_color=("white", "#1A5C1A"))
+        else:
+            window["Check for Match Button"].update(text="Match Tracking: Off", button_color=("white", "#5C0000"))
+    if event == "Hide Completed Checkbox":
+        display_champion_list(window)
     if isinstance(event, tuple) and len(event) == 3 and event[0] == "Champions Unlocked Table" and event[1] == "+CLICKED+":
         cell = event[2]
         # cell may be an int or a (row, col) tuple depending on PySimpleGUI version/events
@@ -543,37 +647,105 @@ while True:
             if table_data and 0 <= row_index < len(table_data):
                 window.metadata["selected_champion_id"] = get_champion_id(table_data[row_index][0])
     if event == "Tracked Teammates List":
-        tracked_teammates = set(values["Tracked Teammates List"])
-    check_lp_for_victory(game_values)
+        selected = values.get("Tracked Teammates List", [])
+        if selected:
+            raw = selected[0]
+            name = raw[2:] if raw.startswith(("\u2713 ", "  ")) else raw
+            if name in tracked_teammates:
+                tracked_teammates.discard(name)
+            else:
+                tracked_teammates.add(name)
     get_items(game_values)
     read_cfg(game_values)
     display_champion_list(window)
     display_values(window, game_values)
-    send_starting_champion_check(game_values)
     if in_match:
-        game_data = get_game_data()
-        if game_data is None and window.metadata.get("game_connected"):
-            # Was previously connected — game may have just ended. Retry quickly
-            # to capture the final state before the API shuts down.
-            for _ in range(5):
-                time.sleep(0.4)
-                game_data = get_game_data()
-                if game_data is not None:
-                    break
+        check_lp_for_victory(game_values)
+        send_starting_champion_check(game_values)
+
+    # --- collect results from background threads ---
+    game_status, game_data = "api_down", None
+    if in_match and _game_future is not None and _game_future.done():
+        game_status, game_data = _game_future.result()
+
+    champ_select_result = None
+    if in_match and not window.metadata.get("game_connected") and _lcu_future is not None and _lcu_future.done():
+        lcu_ok, in_session, own_ids, teammate_ids, bench_ids = _lcu_future.result()
+        champ_select_result = (lcu_ok, in_session, own_ids, teammate_ids, bench_ids)
+        window.metadata["lcu_status"] = champ_select_result
+
+    # --- fire off next background fetches ---
+    if in_match and (_game_future is None or _game_future.done()):
+        _game_future = _executor.submit(get_game_data)
+    if in_match and not window.metadata.get("game_connected") and (_lcu_future is None or _lcu_future.done()):
+        _lcu_future = _executor.submit(get_champ_select_available_ids)
+
+    # --- update champ select line (now integrated into status text) ---
+    window["Champ Select Text"].update("")
     if game_data is None:
-        if in_match and not window.metadata.get("game_connected"):
-            # Still waiting for the game to finish loading
-            window["In Match Text"].update("In Match: Waiting for game...")
+        if in_match:
+            lcu_status = window.metadata.get("lcu_status")
+            if lcu_status is not None:
+                lcu_ok, in_session, own_ids, teammate_ids, bench_ids = lcu_status
+                if not lcu_ok:
+                    status_str = "Status: Waiting (LCU: client not found)"
+                elif in_session:
+                    own_names = _champ_select_names_from_ids(own_ids | bench_ids, window)
+                    teammate_names = _champ_select_names_from_ids(teammate_ids, window)
+                    parts = []
+                    if own_names:
+                        parts.append("your pick: " + ", ".join(own_names))
+                    elif own_ids or bench_ids:
+                        parts.append("your pick has no checks remaining")
+                    if teammate_names:
+                        parts.append("teammate: " + ", ".join(teammate_names))
+                    if parts:
+                        status_str = "Status: Champ select - " + " | ".join(parts)
+                    else:
+                        status_str = "Status: Champ select (no checks remaining)"
+                else:
+                    status_str = "Status: Waiting for game..."
+            else:
+                status_str = "Status: Waiting for League client..."
+            window["In Match Text"].update(status_str)
+            window.metadata["game_connected"] = False
             update_teammate_selector(window, [])
         else:
-            window["In Match Text"].update("In Match: No Match Found")
+            window["In Match Text"].update("Status: Tracking off")
             update_teammate_selector(window, [])
-            in_match = False
             window.metadata["game_connected"] = False
     else:
-        window.metadata["game_connected"] = True
-        window["In Match Text"].update("In Match: In Match")
-        update_teammate_selector(window, get_available_teammates(game_data))
-        get_objectives_complete(game_data, game_values)
+        player_name = get_player_name(game_data)
+        champion_name = get_champion_name(game_data, player_name) or "Unknown"
+        champion_id = get_champion_id(champion_name)
+        locked = champion_id is not None and champion_id not in unlocked_champion_ids
+
+        if game_status == "loading":
+            window["In Match Text"].update(f"Status: Loading ({champion_name})...")
+            window.metadata["game_connected"] = True
+            update_teammate_selector(window, get_available_teammates(game_data), game_data)
+        elif game_status == "game_over":
+            result = "?"
+            for event in game_data["events"]["Events"]:
+                if event.get("EventName") == "GameEnd":
+                    result = event.get("Result", "?")
+                    break
+            status_str = f"Status: Game over ({champion_name} - {result})"
+            if locked:
+                status_str += " [champion locked]"
+            window["In Match Text"].update(status_str)
+            window.metadata["game_connected"] = True
+            update_teammate_selector(window, get_available_teammates(game_data), game_data)
+            get_objectives_complete(game_data, game_values)
+        else:  # in_game
+            if champion_id is not None:
+                window.metadata["selected_champion_id"] = champion_id
+            status_str = f"Status: In game ({champion_name})"
+            if locked:
+                status_str += " [champion locked]"
+            window["In Match Text"].update(status_str)
+            window.metadata["game_connected"] = True
+            update_teammate_selector(window, get_available_teammates(game_data), game_data)
+            get_objectives_complete(game_data, game_values)
 
 window.close()

--- a/worlds/lol/Connector.py
+++ b/worlds/lol/Connector.py
@@ -54,6 +54,28 @@ if not os.path.exists(game_communication_path):
     os.makedirs(game_communication_path)
 
 
+def _read_auto_select_teammates() -> bool:
+    path = os.path.join(game_communication_path, "Auto_Select_Teammates.cfg")
+    try:
+        if os.path.exists(path):
+            with open(path, 'r') as f:
+                return bool(int(f.read().strip() or "0"))
+    except Exception:
+        pass
+    return False
+
+
+def _write_auto_select_teammates(enabled: bool) -> None:
+    try:
+        with open(os.path.join(game_communication_path, "Auto_Select_Teammates.cfg"), 'w') as f:
+            f.write("1" if enabled else "0")
+    except Exception:
+        pass
+
+
+auto_select_teammates = _read_auto_select_teammates()
+
+
 ###DEFINE FUNCTIONS###
 def get_game_data():
     """Returns (status, data) where status is one of:
@@ -138,13 +160,24 @@ def _champion_row_color(champion_id, window):
         return "#5C0000"  # dark red — locked
     active_location_ids  = window.metadata.get("active_location_ids")  if hasattr(window, "metadata") else None
     checked_location_ids = window.metadata.get("checked_location_ids") if hasattr(window, "metadata") else None
+    hinted_location_ids = window.metadata.get("hinted_location_ids") if hasattr(window, "metadata") else None
     if active_location_ids is None or checked_location_ids is None:
         return "#1A5C1A"  # green — unlocked, can't count yet
     champ_name = champions[champion_id]["name"]
     prefix = champ_name + " - "
     checked_ids = {int(x) for x in checked_location_ids}
+    hinted_ids = {int(x) for x in hinted_location_ids} if hinted_location_ids is not None else set()
+    unfound_hinted_ids = hinted_ids - checked_ids
     total = sum(1 for n in active_location_ids if n.startswith(prefix))
     done  = sum(1 for n, lid in active_location_ids.items() if n.startswith(prefix) and lid is not None and int(lid) in checked_ids)
+    hinted = any(
+        n.startswith(prefix)
+        and lid is not None
+        and int(lid) in unfound_hinted_ids
+        for n, lid in active_location_ids.items()
+    )
+    if hinted:
+        return "#277997"  # cyan — has a hinted open check
     remaining = max(0, total - done)
     return "#1A5C1A" if remaining > 0 else "#3A3A3A"  # green / grey
 
@@ -176,6 +209,16 @@ def display_champion_list(window):
                 checked_location_ids = set(ast.literal_eval(f.read()))
     except Exception:
         checked_location_ids = None
+
+    try:
+        path = os.path.join(game_communication_path, "Hinted_Locations.cfg")
+        if os.path.exists(path):
+            with open(path, 'r') as f:
+                hinted_location_ids = set(ast.literal_eval(f.read()))
+        else:
+            hinted_location_ids = None
+    except Exception:
+        hinted_location_ids = None
 
     # Build totals per champion from active_locations (names)
     totals = {}
@@ -246,6 +289,7 @@ def display_champion_list(window):
     # Cache for remaining-checks panel
     window.metadata["active_location_ids"] = active_location_ids
     window.metadata["checked_location_ids"] = checked_location_ids
+    window.metadata["hinted_location_ids"] = hinted_location_ids
 
     # Auto-select first champion if none selected yet
     if window.metadata.get("selected_champion_id") is None and champion_table_rows:
@@ -313,12 +357,19 @@ def won_game(game_data):
             return True
     return False
 
+def _player_name_from_record(player_data):
+    # Depending on game state/patch, Live Client Data may expose either key.
+    return player_data.get("riotIdGameName") or player_data.get("summonerName")
+
 def get_player_name(game_data):
-    return game_data["activePlayer"]["riotIdGameName"]
+    active_player = game_data.get("activePlayer", {})
+    return _player_name_from_record(active_player)
 
 def get_champion_name(game_data, player_name):
+    if not player_name:
+        return None
     for player in game_data["allPlayers"]:
-        if player["riotIdGameName"] == player_name:
+        if _player_name_from_record(player) == player_name:
             return player["championName"]
 
 def get_champion_id(champion_name):
@@ -328,30 +379,44 @@ def get_champion_id(champion_name):
 
 def get_available_teammates(game_data):
     player_name = get_player_name(game_data)
+    if not player_name:
+        return []
     player_team = None
     for player in game_data["allPlayers"]:
-        if player["riotIdGameName"] == player_name:
+        if _player_name_from_record(player) == player_name:
             player_team = player.get("team")
             break
     if player_team is None:
         return []
     teammate_names = []
     for player in game_data["allPlayers"]:
-        if player.get("team") == player_team and player["riotIdGameName"] != player_name:
-            teammate_names.append(player["riotIdGameName"])
+        name = _player_name_from_record(player)
+        if player.get("team") == player_team and name and name != player_name:
+            teammate_names.append(name)
     return sorted(teammate_names)
 
 def update_teammate_selector(window, teammate_names, game_data=None):
     display = []
+    auto_track = window["Auto Select Teammates"].get() if "Auto Select Teammates" in window.AllKeysDict else auto_select_teammates
     for name in teammate_names:
-        tracking = "✓ " if name in tracked_teammates else "  "
+        tracking = "✓ " if auto_track or name in tracked_teammates else "  "
         display.append(tracking + name)
     window["Tracked Teammates List"].update(values=display)
 
 def get_tracked_players(game_data):
     player_name = get_player_name(game_data)
+    if not player_name:
+        return []
     teammate_names = set(get_available_teammates(game_data))
-    selected_teammates = sorted(tracked_teammates.intersection(teammate_names))
+    # Always use the current checkbox value, not the global
+    try:
+        auto_track = window["Auto Select Teammates"].get()
+    except Exception:
+        auto_track = False
+    if auto_track:
+        selected_teammates = sorted(teammate_names)
+    else:
+        selected_teammates = sorted(tracked_teammates.intersection(teammate_names))
     return [player_name] + selected_teammates
 
 def assisted_tower(game_data, player_name):
@@ -374,25 +439,25 @@ def assisted_epic_monster(game_data, player_name, monster_name):
 
 def player_vision_score(game_data, player_name):
     for player in game_data["allPlayers"]:
-        if player["riotIdGameName"] == player_name:
+        if _player_name_from_record(player) == player_name:
             return player["scores"]["wardScore"]
     return 0
 
 def player_creep_score(game_data, player_name):
     for player in game_data["allPlayers"]:
-        if player["riotIdGameName"] == player_name:
+        if _player_name_from_record(player) == player_name:
             return player["scores"]["creepScore"]
     return 0
 
 def player_kills(game_data, player_name):
     for player in game_data["allPlayers"]:
-        if player["riotIdGameName"] == player_name:
+        if _player_name_from_record(player) == player_name:
             return player["scores"]["kills"]
     return 0
 
 def player_assists(game_data, player_name):
     for player in game_data["allPlayers"]:
-        if player["riotIdGameName"] == player_name:
+        if _player_name_from_record(player) == player_name:
             return player["scores"]["assists"]
     return 0
 
@@ -585,7 +650,8 @@ layout = [  [
                         size=(22, 5),
                         enable_events=True,
                         key="Tracked Teammates List",
-                        no_scrollbar=True)]
+                        no_scrollbar=True)],
+                    [sg.Checkbox("Auto Select All", key="Auto Select Teammates", default=auto_select_teammates)]
                ])
             ]
         ]
@@ -610,6 +676,10 @@ while True:
             window["Check for Match Button"].update(text="Match Tracking: Off", button_color=("white", "#5C0000"))
     if event == "Hide Completed Checkbox":
         display_champion_list(window)
+    if event == "Auto Select Teammates":
+        auto_select_teammates = window["Auto Select Teammates"].get()
+        if game_data is not None:
+            update_teammate_selector(window, get_available_teammates(game_data), game_data)
     if isinstance(event, tuple) and len(event) == 3 and event[0] == "Champions Unlocked Table" and event[1] == "+CLICKED+":
         cell = event[2]
         # cell may be an int or a (row, col) tuple depending on PySimpleGUI version/events
@@ -647,14 +717,15 @@ while True:
             if table_data and 0 <= row_index < len(table_data):
                 window.metadata["selected_champion_id"] = get_champion_id(table_data[row_index][0])
     if event == "Tracked Teammates List":
-        selected = values.get("Tracked Teammates List", [])
-        if selected:
-            raw = selected[0]
-            name = raw[2:] if raw.startswith(("\u2713 ", "  ")) else raw
-            if name in tracked_teammates:
-                tracked_teammates.discard(name)
-            else:
-                tracked_teammates.add(name)
+        if not auto_select_teammates:
+            selected = values.get("Tracked Teammates List", [])
+            if selected:
+                raw = selected[0]
+                name = raw[2:] if raw.startswith(("\u2713 ", "  ")) else raw
+                if name in tracked_teammates:
+                    tracked_teammates.discard(name)
+                else:
+                    tracked_teammates.add(name)
     get_items(game_values)
     read_cfg(game_values)
     display_champion_list(window)

--- a/worlds/lol/Connector.py
+++ b/worlds/lol/Connector.py
@@ -5,6 +5,7 @@ import os
 import ast
 import sys
 import unicodedata
+import threading
 from concurrent.futures import ThreadPoolExecutor
 
 ###GET VERSION###
@@ -630,29 +631,184 @@ def send_locations(objectives_complete, champion_id):
 ###LCU / CHAMP SELECT###
 
 _lockfile_path_cache = None
+_lockfile_lock = threading.Lock()
+_lockfile_prompting = False  # Flag to prevent concurrent prompts
+_prompt_event = None
+_prompt_result = None
+
+def _get_cached_lockfile_path() -> str:
+    """Load cached lockfile path from config. Returns None if not found or empty (user declined)."""
+    try:
+        cache_file = os.path.join(game_communication_path, "Lockfile_Path.cfg")
+        if os.path.exists(cache_file):
+            with open(cache_file, 'r') as f:
+                path = f.read().strip()
+                if path and os.path.exists(path):
+                    return path
+    except Exception:
+        pass
+    return None
+
+def _save_lockfile_path(path: str) -> None:
+    """Cache the lockfile path or install folder to config."""
+    try:
+        cache_file = os.path.join(game_communication_path, "Lockfile_Path.cfg")
+        with open(cache_file, 'w') as f:
+            f.write(path)
+    except Exception:
+        pass
+
+def _clear_cached_lockfile_path() -> None:
+    """Remove cached lockfile path."""
+    try:
+        cache_file = os.path.join(game_communication_path, "Lockfile_Path.cfg")
+        if os.path.exists(cache_file):
+            os.remove(cache_file)
+    except Exception:
+        pass
+
+
+def _prompt_for_league_path() -> str:
+    """Ask user to select League install folder or executable."""
+    try:
+        # Keep prompting until user selects a folder with a valid lockfile or cancels.
+        while True:
+            result = sg.popup_get_folder(
+                "League Client not found automatically.\n\n"
+                "Please select your League of Legends installation folder\n"
+                "(the folder containing LeagueClientUx.exe)",
+                title="Select League of Legends Folder"
+            )
+            if not result:
+                # user cancelled
+                return None
+            if os.path.exists(result):
+                lockfile_path = os.path.join(result, "lockfile")
+                exe_path = os.path.join(result, "LeagueClientUx.exe")
+                if os.path.exists(lockfile_path):
+                    _save_lockfile_path(lockfile_path)
+                    return lockfile_path
+                # If the folder contains the League executable, accept and cache the folder.
+                if os.path.exists(exe_path):
+                    _save_lockfile_path(result)
+                    sg.popup('Selected folder saved. Lockfile will be detected when the League client runs.', title='Folder Saved')
+                    return result
+                else:
+                    sg.popup('Selected folder does not contain LeagueClientUx.exe. Please select the folder containing LeagueClientUx.exe.', title='Invalid Folder')
+                    continue
+            else:
+                sg.popup('Selected path does not exist. Please choose a valid folder.', title='Invalid Path')
+                continue
+    except Exception:
+        pass
+    return None
 
 def _read_lockfile():
     import subprocess
-    global _lockfile_path_cache
+    global _lockfile_path_cache, _lockfile_lock, _lockfile_prompting, _prompt_event, _prompt_result
+
+    # Fast-path: cached path. Cache may be either a lockfile path (file) or an install folder (dir).
+    if _lockfile_path_cache and _lockfile_path_cache != "":
+        try:
+            # If cached is a file, assume it's the lockfile
+            if os.path.isfile(_lockfile_path_cache):
+                with open(_lockfile_path_cache, 'r') as f:
+                    parts = f.read().strip().split(':')
+                if len(parts) >= 4:
+                    return parts[2].strip(), parts[3].strip()
+                return None, None
+
+            # If cached is a directory, look for 'lockfile' inside it. If not present, poll briefly.
+            if os.path.isdir(_lockfile_path_cache):
+                lockfile_path = os.path.join(_lockfile_path_cache, 'lockfile')
+                if not os.path.exists(lockfile_path):
+                    import time
+                    # wait up to 10s for the client to start and create lockfile
+                    for _ in range(10):
+                        time.sleep(1)
+                        if os.path.exists(lockfile_path):
+                            break
+                if os.path.exists(lockfile_path):
+                    _save_lockfile_path(lockfile_path)
+                    with open(lockfile_path, 'r') as f:
+                        parts = f.read().strip().split(':')
+                    if len(parts) >= 4:
+                        return parts[2].strip(), parts[3].strip()
+                return None, None
+        except Exception:
+            pass
+        return None, None
+
     try:
         if _lockfile_path_cache is None:
-            result = subprocess.run(
-                ["wmic", "process", "where", "name='LeagueClientUx.exe'", "get", "ExecutablePath", "/value"],
-                capture_output=True, text=True, timeout=3,
-                creationflags=subprocess.CREATE_NO_WINDOW
-            )
-            exe = ""
-            for line in result.stdout.splitlines():
-                if "ExecutablePath=" in line:
-                    exe = line.split("=", 1)[1].strip()
-                    break
-            if not exe:
-                return None, None
-            _lockfile_path_cache = os.path.join(os.path.dirname(exe), "lockfile")
-        with open(_lockfile_path_cache, 'r') as f:
-            parts = f.read().strip().split(':')
-        if len(parts) >= 4:
-            return parts[2].strip(), parts[3].strip()
+            with _lockfile_lock:
+                # Double-check state
+                if _lockfile_path_cache is not None:
+                    pass
+                elif _lockfile_prompting:
+                    return None, None
+                else:
+                    # cached path on disk
+                    cached = _get_cached_lockfile_path()
+                    if cached:
+                        _lockfile_path_cache = cached
+                    else:
+                        # Try WMIC-based detection
+                        try:
+                            result = subprocess.run(
+                                ["wmic", "process", "where", "name='LeagueClientUx.exe'", "get", "ExecutablePath", "/value"],
+                                capture_output=True, text=True, timeout=3,
+                                creationflags=subprocess.CREATE_NO_WINDOW
+                            )
+                            exe = ""
+                            for line in result.stdout.splitlines():
+                                if "ExecutablePath=" in line:
+                                    exe = line.split("=", 1)[1].strip()
+                                    break
+                            if exe:
+                                lockfile_path = os.path.join(os.path.dirname(exe), "lockfile")
+                                if os.path.exists(lockfile_path):
+                                    _lockfile_path_cache = lockfile_path
+                                    _save_lockfile_path(lockfile_path)
+                        except Exception:
+                            pass
+
+                        # If WMIC failed, request the main thread to prompt the user
+                        if _lockfile_path_cache is None:
+                            if 'window' in globals() and window is not None:
+                                _lockfile_prompting = True
+                                res = None
+                                try:
+                                    _prompt_event = threading.Event()
+                                    _prompt_result = None
+                                    window.write_event_value('SHOW_LEAGUE_PROMPT', None)
+                                    # wait up to 30s for user to respond
+                                    if _prompt_event.wait(30):
+                                        res = _prompt_result
+                                    else:
+                                        res = None
+                                finally:
+                                    _lockfile_prompting = False
+                                    _prompt_event = None
+                                    _prompt_result = None
+                                _lockfile_path_cache = res if res else None
+                            else:
+                                # Fallback: blocking popup in background (rare)
+                                _lockfile_prompting = True
+                                try:
+                                    user_result = _prompt_for_league_path()
+                                    _lockfile_path_cache = user_result if user_result else None
+                                finally:
+                                    _lockfile_prompting = False
+                if _lockfile_path_cache is None:
+                    return None, None
+
+        # Parse lockfile contents
+        if _lockfile_path_cache:
+            with open(_lockfile_path_cache, 'r') as f:
+                parts = f.read().strip().split(':')
+            if len(parts) >= 4:
+                return parts[2].strip(), parts[3].strip()
     except Exception:
         _lockfile_path_cache = None
     return None, None
@@ -717,7 +873,7 @@ _THEME_BG = "#2c2825"
 layout = [  [
                 sg.Text('In Match: No', justification = 'center', key = "In Match Text"),
                 sg.Button('Match Tracking: Off', key = "Check for Match Button", button_color=("white", "#5C0000")),
-                sg.Text('', key = "Champ Select Text", text_color="yellow")
+                sg.Text('', key = "Champ Select Text", text_color="yellow"),
             ],
             [   
                 sg.Column(
@@ -763,6 +919,54 @@ while True:
     event, values = window.read(timeout=500)
     if event == sg.WIN_CLOSED:
         break
+    # Main-thread handler for lockfile prompt requests from background threads
+    if event == 'SHOW_LEAGUE_PROMPT':
+        try:
+            # Show folder dialog on main thread
+            result = sg.popup_get_folder(
+                "League Client not found automatically.\n\n"
+                "Please select your League of Legends installation folder\n"
+                "(the folder containing LeagueClientUx.exe)",
+                title="Select League of Legends Folder"
+            )
+            if result and os.path.exists(result):
+                lockfile_path = os.path.join(result, "lockfile")
+                exe_path = os.path.join(result, "LeagueClientUx.exe")
+                if os.path.exists(lockfile_path):
+                    _save_lockfile_path(lockfile_path)
+                    try:
+                        _prompt_result = lockfile_path
+                    except Exception:
+                        pass
+                elif os.path.exists(exe_path):
+                    # Accept and cache install folder even if client not running yet
+                    _save_lockfile_path(result)
+                    try:
+                        _prompt_result = result
+                    except Exception:
+                        pass
+                else:
+                    try:
+                        _prompt_result = None
+                    except Exception:
+                        pass
+            else:
+                try:
+                    _prompt_result = None
+                except Exception:
+                    pass
+        except Exception:
+            try:
+                _prompt_result = None
+            except Exception:
+                pass
+        finally:
+            try:
+                if _prompt_event is not None:
+                    _prompt_event.set()
+            except Exception:
+                pass
+        continue
     if event == 'Check for Match Button':
         in_match = not in_match
         window.metadata["game_connected"] = False
@@ -770,6 +974,7 @@ while True:
             window["Check for Match Button"].update(text="Match Tracking: On", button_color=("white", "#1A5C1A"))
         else:
             window["Check for Match Button"].update(text="Match Tracking: Off", button_color=("white", "#5C0000"))
+    # 'Change Folder' removed -- folder selection is handled via automatic prompt when needed.
     if event == "Hide Completed Checkbox":
         display_champion_list(window)
     if event == "Auto Select Teammates":

--- a/worlds/lol/Connector.py
+++ b/worlds/lol/Connector.py
@@ -4,6 +4,7 @@ import requests
 import os
 import ast
 import sys
+import unicodedata
 from concurrent.futures import ThreadPoolExecutor
 
 ###GET VERSION###
@@ -361,37 +362,132 @@ def _player_name_from_record(player_data):
     # Depending on game state/patch, Live Client Data may expose either key.
     return player_data.get("riotIdGameName") or player_data.get("summonerName")
 
+
+def _name_candidates_from_record(player_data):
+    candidates = set()
+    if not isinstance(player_data, dict):
+        return candidates
+    for key in ("riotIdGameName", "summonerName"):
+        value = player_data.get(key)
+        if not value:
+            continue
+        text = str(value).strip()
+        if not text:
+            continue
+        candidates.add(text.casefold())
+        if "#" in text:
+            candidates.add(text.split("#", 1)[0].casefold())
+    return candidates
+
+
+def _name_candidates_from_text(name_text):
+    candidates = set()
+    if not name_text:
+        return candidates
+    text = str(name_text).strip()
+    if not text:
+        return candidates
+    candidates.add(text.casefold())
+    if "#" in text:
+        candidates.add(text.split("#", 1)[0].casefold())
+    return candidates
+
+
+def _find_player_record(game_data, player_name):
+    target_candidates = _name_candidates_from_text(player_name)
+    if not target_candidates:
+        return None
+    for player in game_data.get("allPlayers", []):
+        if target_candidates.intersection(_name_candidates_from_record(player)):
+            return player
+    active_player = game_data.get("activePlayer", {})
+    if target_candidates.intersection(_name_candidates_from_record(active_player)):
+        return active_player
+    return None
+
 def get_player_name(game_data):
     active_player = game_data.get("activePlayer", {})
     return _player_name_from_record(active_player)
 
+def _champion_name_from_raw(raw_champion_name):
+    """Map raw champion key (if present) to the Data Dragon display name."""
+    if not raw_champion_name:
+        return None
+    token = str(raw_champion_name).split("_")[-1]
+    for champion_id in champions:
+        dd_id = champions[champion_id].get("id")
+        if dd_id and str(dd_id).casefold() == token.casefold():
+            return champions[champion_id]["name"]
+    return None
+
+def _normalize_champion_text(text: str) -> str:
+    """Accent/format-insensitive champion name normalization."""
+    normalized = unicodedata.normalize("NFKD", text)
+    stripped = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    return "".join(ch for ch in stripped.casefold() if ch.isalnum())
+
 def get_champion_name(game_data, player_name):
     if not player_name:
         return None
+    active_candidates = _name_candidates_from_record(game_data.get("activePlayer", {}))
+    if player_name:
+        active_candidates.add(str(player_name).casefold())
     for player in game_data["allPlayers"]:
-        if _player_name_from_record(player) == player_name:
-            return player["championName"]
+        player_candidates = _name_candidates_from_record(player)
+        if active_candidates.intersection(player_candidates):
+            from_raw = _champion_name_from_raw(player.get("rawChampionName"))
+            if from_raw:
+                return from_raw
+            return player.get("championName")
+    active_player = game_data.get("activePlayer", {})
+    from_raw = _champion_name_from_raw(active_player.get("rawChampionName"))
+    if from_raw:
+        return from_raw
+    return active_player.get("championName")
 
 def get_champion_id(champion_name):
+    if not champion_name:
+        return None
     for champion_id in champions:
         if champions[champion_id]["name"] == champion_name:
             return champion_id
+    wanted = _normalize_champion_text(champion_name)
+    for champion_id in champions:
+        data = champions[champion_id]
+        if _normalize_champion_text(data["name"]) == wanted:
+            return champion_id
+        dd_id = data.get("id")
+        if dd_id and _normalize_champion_text(str(dd_id)) == wanted:
+            return champion_id
+
+
+def get_active_player_champion_id(game_data):
+    active_player = game_data.get("activePlayer", {})
+    from_raw = _champion_name_from_raw(active_player.get("rawChampionName"))
+    if from_raw:
+        return get_champion_id(from_raw)
+    champion_name = active_player.get("championName")
+    if champion_name:
+        return get_champion_id(champion_name)
+    return None
 
 def get_available_teammates(game_data):
     player_name = get_player_name(game_data)
     if not player_name:
         return []
-    player_team = None
-    for player in game_data["allPlayers"]:
-        if _player_name_from_record(player) == player_name:
-            player_team = player.get("team")
-            break
+    player_record = _find_player_record(game_data, player_name)
+    if player_record is None:
+        return []
+    player_team = player_record.get("team")
     if player_team is None:
         return []
+    own_candidates = _name_candidates_from_record(player_record)
     teammate_names = []
     for player in game_data["allPlayers"]:
         name = _player_name_from_record(player)
-        if player.get("team") == player_team and name and name != player_name:
+        if (player.get("team") == player_team
+                and name
+                and not own_candidates.intersection(_name_candidates_from_record(player))):
             teammate_names.append(name)
     return sorted(teammate_names)
 
@@ -438,27 +534,27 @@ def assisted_epic_monster(game_data, player_name, monster_name):
     return False
 
 def player_vision_score(game_data, player_name):
-    for player in game_data["allPlayers"]:
-        if _player_name_from_record(player) == player_name:
-            return player["scores"]["wardScore"]
+    player = _find_player_record(game_data, player_name)
+    if player is not None:
+        return player.get("scores", {}).get("wardScore", 0)
     return 0
 
 def player_creep_score(game_data, player_name):
-    for player in game_data["allPlayers"]:
-        if _player_name_from_record(player) == player_name:
-            return player["scores"]["creepScore"]
+    player = _find_player_record(game_data, player_name)
+    if player is not None:
+        return player.get("scores", {}).get("creepScore", 0)
     return 0
 
 def player_kills(game_data, player_name):
-    for player in game_data["allPlayers"]:
-        if _player_name_from_record(player) == player_name:
-            return player["scores"]["kills"]
+    player = _find_player_record(game_data, player_name)
+    if player is not None:
+        return player.get("scores", {}).get("kills", 0)
     return 0
 
 def player_assists(game_data, player_name):
-    for player in game_data["allPlayers"]:
-        if _player_name_from_record(player) == player_name:
-            return player["scores"]["assists"]
+    player = _find_player_record(game_data, player_name)
+    if player is not None:
+        return player.get("scores", {}).get("assists", 0)
     return 0
 
 def vision_score_above(game_data, player_name, score_target):
@@ -808,6 +904,12 @@ while True:
             window.metadata["game_connected"] = True
             update_teammate_selector(window, get_available_teammates(game_data), game_data)
             get_objectives_complete(game_data, game_values)
+            # Some patches/locales can make end-of-game identity matching flaky.
+            # Ensure own champion's Game Win objective is emitted on a confirmed win.
+            if won_game(game_data):
+                active_champion_id = get_active_player_champion_id(game_data)
+                if active_champion_id is not None and active_champion_id in unlocked_champion_ids:
+                    send_locations([10], active_champion_id)
         else:  # in_game
             if champion_id is not None:
                 window.metadata["selected_champion_id"] = champion_id

--- a/worlds/lol/Items.py
+++ b/worlds/lol/Items.py
@@ -31,6 +31,51 @@ for champion_id in champions:
     item_table[champions[champion_id]["name"]] = LOLItemData("Champion", code = 565_000000 + int(champion_id), classification = ItemClassification.progression, max_quantity = 1, weight = 1)
 item_table["LP"] = LOLItemData("Win Condition", code = 565_000000, classification = ItemClassification.progression, max_quantity = -1, weight = 1)
 
+filler_item_names = [
+    "Black Spear",
+    "Cull",
+    "Dark Seal",
+    "Doran's Blade",
+    "Doran's Ring",
+    "Doran's Shield",
+    "Guardian's Amulet",
+    "Guardian's Blade",
+    "Guardian's Dirk",
+    "Guardian's Hammer",
+    "Guardian's Horn",
+    "Guardian's Orb",
+    "Guardian's Shroud",
+    "Gustwalker Hatchling",
+    "Mosstomper Seedling",
+    "Scorchclaw Pup",
+    "Tear of the Goddess",
+    "World Atlas",
+    "Amplifying Tome",
+    "B. F. Sword",
+    "Blasting Wand",
+    "Cloak of Agility",
+    "Cloth Armor",
+    "Dagger",
+    "Faerie Charm",
+    "Glowing Mote",
+    "Long Sword",
+    "Needlessly Large Rod",
+    "Null-Magic Mantle",
+    "Pickaxe",
+    "Rejuvenation Bead",
+    "Ruby Crystal",
+    "Sapphire Crystal",
+]
+
+for index, item_name in enumerate(filler_item_names, start=1):
+    item_table[item_name] = LOLItemData(
+        "Filler",
+        code=565_100000 + index,
+        classification=ItemClassification.filler,
+        max_quantity=-1,
+        weight=1,
+    )
+
 
 event_item_table: Dict[str, LOLItemData] = {
 }

--- a/worlds/lol/Locations.py
+++ b/worlds/lol/Locations.py
@@ -39,11 +39,10 @@ for champion_id in champions:
         location_table[champion_name + " - Get X Kills"]           = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 8)
         location_table[champion_name + " - Get X Creep Score"]     = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 9)
 
-location_table["Starting Champion 1"] = LOLLocationData("Starting", 566_000001)
-location_table["Starting Champion 2"] = LOLLocationData("Starting", 566_000002)
-location_table["Starting Champion 3"] = LOLLocationData("Starting", 566_000003)
-location_table["Starting Champion 4"] = LOLLocationData("Starting", 566_000004)
-location_table["Starting Champion 5"] = LOLLocationData("Starting", 566_000005)
+for index in range(1, 101):
+    location_table[f"Starting Champion {index}"] = LOLLocationData("Starting", 566_000000 + index)
+
+location_table["Game Win - Enemy Nexus Destroyed"] = LOLLocationData("Objective", 566_900001)
 
 event_location_table: Dict[str, LOLLocationData] = {
 }

--- a/worlds/lol/Locations.py
+++ b/worlds/lol/Locations.py
@@ -32,6 +32,7 @@ for champion_id in champions:
     location_table[champion_name + " - Assist Taking Baron"]       = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 3)
     location_table[champion_name + " - Assist Taking Tower"]       = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 4)
     location_table[champion_name + " - Assist Taking Inhibitor"]   = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 5)
+    location_table[champion_name + " - Enemy Nexus Destroyed"]     = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 10)
     location_table[champion_name + " - Get X Assists"]             = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 6)
     if "Support" in champions[champion_id]["tags"]:
         location_table[champion_name + " - Get X Ward Score"]      = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 7)
@@ -39,11 +40,8 @@ for champion_id in champions:
         location_table[champion_name + " - Get X Kills"]           = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 8)
         location_table[champion_name + " - Get X Creep Score"]     = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 9)
 
-location_table["Starting Champion 1"] = LOLLocationData("Starting", 566_000001)
-location_table["Starting Champion 2"] = LOLLocationData("Starting", 566_000002)
-location_table["Starting Champion 3"] = LOLLocationData("Starting", 566_000003)
-location_table["Starting Champion 4"] = LOLLocationData("Starting", 566_000004)
-location_table["Starting Champion 5"] = LOLLocationData("Starting", 566_000005)
+for index in range(1, 101):
+    location_table[f"Starting Champion {index}"] = LOLLocationData("Starting", 566_000000 + index)
 
 event_location_table: Dict[str, LOLLocationData] = {
 }

--- a/worlds/lol/Locations.py
+++ b/worlds/lol/Locations.py
@@ -24,6 +24,40 @@ def get_locations_by_category(category: str) -> Dict[str, LOLLocationData]:
     return location_dict
 
 
+# Maps enabled check option names to their location name suffix
+CHECK_TO_LOCATION: Dict[str, str] = {
+    "Dragon":       " - Assist Taking Dragon",
+    "Herald":       " - Assist Taking Rift Herald",
+    "Baron":        " - Assist Taking Baron",
+    "Tower":        " - Assist Taking Tower",
+    "Inhibitor":    " - Assist Taking Inhibitor",
+    "Game Win":     " - Enemy Nexus Destroyed",
+    "Assists":      " - Get X Assists",
+    "Vision Score": " - Get X Ward Score",
+    "Kills":        " - Get X Kills",
+    "Creep Score":  " - Get X Creep Score",
+}
+
+_SUPPORT_ONLY_CHECKS = frozenset({"Vision Score"})
+_NON_SUPPORT_CHECKS  = frozenset({"Kills", "Creep Score"})
+
+
+def get_champion_location_suffixes(champion_id, enabled_checks, support_special_treatment: bool) -> list:
+    """Return the list of active location suffixes for a champion given the current options."""
+    is_support = "Support" in champions[champion_id]["tags"]
+    result = []
+    for check, suffix in CHECK_TO_LOCATION.items():
+        if check not in enabled_checks:
+            continue
+        if support_special_treatment:
+            if check in _SUPPORT_ONLY_CHECKS and not is_support:
+                continue
+            if check in _NON_SUPPORT_CHECKS and is_support:
+                continue
+        result.append(suffix)
+    return result
+
+
 location_table: Dict[str, LOLLocationData] = {}
 for champion_id in champions:
     champion_name = champions[champion_id]["name"]
@@ -34,11 +68,9 @@ for champion_id in champions:
     location_table[champion_name + " - Assist Taking Inhibitor"]   = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 5)
     location_table[champion_name + " - Enemy Nexus Destroyed"]     = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 10)
     location_table[champion_name + " - Get X Assists"]             = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 6)
-    if "Support" in champions[champion_id]["tags"]:
-        location_table[champion_name + " - Get X Ward Score"]      = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 7)
-    if "Support" not in champions[champion_id]["tags"]:
-        location_table[champion_name + " - Get X Kills"]           = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 8)
-        location_table[champion_name + " - Get X Creep Score"]     = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 9)
+    location_table[champion_name + " - Get X Ward Score"]          = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 7)
+    location_table[champion_name + " - Get X Kills"]               = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 8)
+    location_table[champion_name + " - Get X Creep Score"]         = LOLLocationData("Objective", 566_000000 + (int(champion_id) * 100) + 9)
 
 for index in range(1, 101):
     location_table[f"Starting Champion {index}"] = LOLLocationData("Starting", 566_000000 + index)

--- a/worlds/lol/Options.py
+++ b/worlds/lol/Options.py
@@ -15,6 +15,16 @@ class RequiredLPPercentage(Range):
     range_end = 100
     display_name = "Required LP Percentage"
 
+
+class TotalLPCount(Range):
+    """
+    Total LP items to place in the world.
+    """
+    default = 80
+    range_start = 1
+    range_end = 500
+    display_name = "Total LP Count"
+
 class Champions(OptionSet):
     """
     Which champions are possibly included in the item pool?
@@ -65,7 +75,7 @@ class StartingChampions(Range):
     """
     default = 3
     range_start = 1
-    range_end = 5
+    range_end = 100
     display_name = "Starting Champions"
 
 class ChampionSubsetCount(Range):
@@ -77,6 +87,13 @@ class ChampionSubsetCount(Range):
     range_end = 200
     display_name = "Champion Subset Count"
 
+class ARAMMode(Toggle):
+    """
+    Enable ARAM mode. The only checks enabled are:
+    Tower, Inhibitor, Assists, and Kills.
+    """
+    display_name = "ARAM Mode"
+
 @dataclass
 class LOLOptions(PerGameCommonOptions):
     champions: Champions
@@ -84,6 +101,8 @@ class LOLOptions(PerGameCommonOptions):
     required_vision_score: RequiredVisionScore
     required_kills: RequiredKills
     required_assists: RequiredAssists
+    total_lp_count: TotalLPCount
     required_lp: RequiredLPPercentage
     starting_champions: StartingChampions
     champion_subset_count: ChampionSubsetCount
+    aram_mode: ARAMMode

--- a/worlds/lol/Options.py
+++ b/worlds/lol/Options.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, asdict
 
-from Options import Choice, Range, Option, Toggle, DeathLink, DefaultOnToggle, OptionSet, PerGameCommonOptions
+from Options import Choice, Range, Option, Toggle, DeathLink, DefaultOnToggle, OptionSet, PerGameCommonOptions, OptionGroup
 
 from .Data import champions
 
@@ -81,28 +81,75 @@ class StartingChampions(Range):
 class ChampionSubsetCount(Range):
     """
     Number of champions to randomly select for the item pool of those listed provided.
+    Higher then the total number of champions will just use all champions listed.
     """
     default = 20
     range_start = 1
     range_end = 200
     display_name = "Champion Subset Count"
 
-class ARAMMode(Toggle):
+class EnabledChecks(OptionSet):
     """
-    Enable ARAM mode. The only checks enabled are:
-    Tower, Inhibitor, Assists, and Kills.
+    Which check types are active for each champion?
+    All check types are enabled by default: "Dragon", "Herald", "Baron", "Tower", "Inhibitor", 
+    "Game Win", "Assists", "Kills", "Creep Score", "Vision Score"
+    To recreate the old ARAM mode, use: "Tower", "Inhibitor", "Game Win", "Assists", "Kills"
     """
-    display_name = "ARAM Mode"
+    display_name = "Enabled Checks"
+    valid_keys = ["Dragon", "Herald", "Baron", "Tower", "Inhibitor", "Game Win",
+                  "Assists", "Kills", "Creep Score", "Vision Score"]
+    default = sorted({"Dragon", "Herald", "Baron", "Tower", "Inhibitor", "Game Win",
+                      "Assists", "Kills", "Creep Score", "Vision Score"})
+
+class SupportSpecialTreatment(DefaultOnToggle):
+    """
+    When enabled, support-role champions will not receive Kill and Creep Score checks,
+    and Vision Score checks will only apply to support champions.
+    (This was enabled by default on version <=0.2.0)
+    Disable this to give all champions identical checks.
+    """
+    display_name = "Support Special Treatment"
+
+class WinCompletesChampion(Toggle):
+    """
+    If enabled, winning a game with a champion (Enemy Nexus Destroyed check) will
+    automatically complete all remaining checks for that champion.
+    """
+    display_name = "Win Completes Champion"
 
 @dataclass
 class LOLOptions(PerGameCommonOptions):
     champions: Champions
+    starting_champions: StartingChampions
+    champion_subset_count: ChampionSubsetCount
+    enabled_checks: EnabledChecks
+    support_special_treatment: SupportSpecialTreatment
+    win_completes_champion: WinCompletesChampion
     required_creep_score: RequiredCreepScore
     required_vision_score: RequiredVisionScore
     required_kills: RequiredKills
     required_assists: RequiredAssists
     total_lp_count: TotalLPCount
     required_lp: RequiredLPPercentage
-    starting_champions: StartingChampions
-    champion_subset_count: ChampionSubsetCount
-    aram_mode: ARAMMode
+
+
+lol_option_groups = [
+    OptionGroup("Champion Options", [
+        Champions,
+        StartingChampions,
+        ChampionSubsetCount,
+    ]),
+    OptionGroup("Check Options", [
+        EnabledChecks,
+        SupportSpecialTreatment,
+        WinCompletesChampion,
+        RequiredCreepScore,
+        RequiredVisionScore,
+        RequiredKills,
+        RequiredAssists,
+    ]),
+    OptionGroup("Goal Options", [
+        TotalLPCount,
+        RequiredLPPercentage,
+    ]),
+]

--- a/worlds/lol/PySimpleGUI.py
+++ b/worlds/lol/PySimpleGUI.py
@@ -1,0 +1,1 @@
+from FreeSimpleGUI import *

--- a/worlds/lol/Regions.py
+++ b/worlds/lol/Regions.py
@@ -18,20 +18,24 @@ def create_regions(multiworld: MultiWorld, player: int, options, possible_champi
 
     # Set up locations
     
+    aram = bool(options.aram_mode)
     for champion_id in champions:
         champion_name = champions[champion_id]["name"]
         if champion_name in possible_champions:
-            regions["Match"].locations.append(champion_name + " - Assist Taking Dragon")
-            regions["Match"].locations.append(champion_name + " - Assist Taking Rift Herald")
-            regions["Match"].locations.append(champion_name + " - Assist Taking Baron")
+            if not aram:
+                regions["Match"].locations.append(champion_name + " - Assist Taking Dragon")
+                regions["Match"].locations.append(champion_name + " - Assist Taking Rift Herald")
+                regions["Match"].locations.append(champion_name + " - Assist Taking Baron")
             regions["Match"].locations.append(champion_name + " - Assist Taking Tower")
             regions["Match"].locations.append(champion_name + " - Assist Taking Inhibitor")
+            regions["Match"].locations.append(champion_name + " - Enemy Nexus Destroyed")
             regions["Match"].locations.append(champion_name + " - Get X Assists")
-            if "Support" in champions[champion_id]["tags"]:
+            if not aram and "Support" in champions[champion_id]["tags"]:
                 regions["Match"].locations.append(champion_name + " - Get X Ward Score")
             if "Support" not in champions[champion_id]["tags"]:
                 regions["Match"].locations.append(champion_name + " - Get X Kills")
-                regions["Match"].locations.append(champion_name + " - Get X Creep Score")
+                if not aram:
+                    regions["Match"].locations.append(champion_name + " - Get X Creep Score")
     for i in range(min(options.starting_champions, len(possible_champions))):
         regions["Match"].locations.append("Starting Champion " + str(i+1))
     

--- a/worlds/lol/Regions.py
+++ b/worlds/lol/Regions.py
@@ -18,22 +18,26 @@ def create_regions(multiworld: MultiWorld, player: int, options, possible_champi
 
     # Set up locations
     
+    aram = bool(options.aram_mode)
     for champion_id in champions:
         champion_name = champions[champion_id]["name"]
         if champion_name in possible_champions:
-            regions["Match"].locations.append(champion_name + " - Assist Taking Dragon")
-            regions["Match"].locations.append(champion_name + " - Assist Taking Rift Herald")
-            regions["Match"].locations.append(champion_name + " - Assist Taking Baron")
+            if not aram:
+                regions["Match"].locations.append(champion_name + " - Assist Taking Dragon")
+                regions["Match"].locations.append(champion_name + " - Assist Taking Rift Herald")
+                regions["Match"].locations.append(champion_name + " - Assist Taking Baron")
             regions["Match"].locations.append(champion_name + " - Assist Taking Tower")
             regions["Match"].locations.append(champion_name + " - Assist Taking Inhibitor")
             regions["Match"].locations.append(champion_name + " - Get X Assists")
-            if "Support" in champions[champion_id]["tags"]:
+            if not aram and "Support" in champions[champion_id]["tags"]:
                 regions["Match"].locations.append(champion_name + " - Get X Ward Score")
             if "Support" not in champions[champion_id]["tags"]:
                 regions["Match"].locations.append(champion_name + " - Get X Kills")
-                regions["Match"].locations.append(champion_name + " - Get X Creep Score")
+                if not aram:
+                    regions["Match"].locations.append(champion_name + " - Get X Creep Score")
     for i in range(min(options.starting_champions, len(possible_champions))):
         regions["Match"].locations.append("Starting Champion " + str(i+1))
+    regions["Match"].locations.append("Game Win - Enemy Nexus Destroyed")
     
     # Set up the regions correctly.
     for name, data in regions.items():

--- a/worlds/lol/Regions.py
+++ b/worlds/lol/Regions.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, NamedTuple, Optional
 
 from BaseClasses import MultiWorld, Region, Entrance
-from .Locations import LOLLocation, location_table, get_locations_by_category
+from .Locations import LOLLocation, location_table, get_locations_by_category, get_champion_location_suffixes
 from .Data import champions
 
 
@@ -17,25 +17,14 @@ def create_regions(multiworld: MultiWorld, player: int, options, possible_champi
     }
 
     # Set up locations
-    
-    aram = bool(options.aram_mode)
+
+    enabled_checks = options.enabled_checks.value
+    sst = bool(options.support_special_treatment)
     for champion_id in champions:
         champion_name = champions[champion_id]["name"]
         if champion_name in possible_champions:
-            if not aram:
-                regions["Match"].locations.append(champion_name + " - Assist Taking Dragon")
-                regions["Match"].locations.append(champion_name + " - Assist Taking Rift Herald")
-                regions["Match"].locations.append(champion_name + " - Assist Taking Baron")
-            regions["Match"].locations.append(champion_name + " - Assist Taking Tower")
-            regions["Match"].locations.append(champion_name + " - Assist Taking Inhibitor")
-            regions["Match"].locations.append(champion_name + " - Enemy Nexus Destroyed")
-            regions["Match"].locations.append(champion_name + " - Get X Assists")
-            if not aram and "Support" in champions[champion_id]["tags"]:
-                regions["Match"].locations.append(champion_name + " - Get X Ward Score")
-            if "Support" not in champions[champion_id]["tags"]:
-                regions["Match"].locations.append(champion_name + " - Get X Kills")
-                if not aram:
-                    regions["Match"].locations.append(champion_name + " - Get X Creep Score")
+            for suffix in get_champion_location_suffixes(champion_id, enabled_checks, sst):
+                regions["Match"].locations.append(champion_name + suffix)
     for i in range(min(options.starting_champions, len(possible_champions))):
         regions["Match"].locations.append("Starting Champion " + str(i+1))
     

--- a/worlds/lol/Rules.py
+++ b/worlds/lol/Rules.py
@@ -9,20 +9,24 @@ def has_at_least(state: CollectionState, player: int, item_name, item_qty_requir
     return state.count(item_name, player) >= item_qty_required
 
 def set_rules(multiworld: MultiWorld, player: int, options, required_lp, possible_champions):
+    aram = bool(options.aram_mode)
     for champion_id in champions:
         champion_name = champions[champion_id]["name"]
         if champion_name in possible_champions:
-            multiworld.get_location(champion_name + " - Assist Taking Dragon"     , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-            multiworld.get_location(champion_name + " - Assist Taking Rift Herald", player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-            multiworld.get_location(champion_name + " - Assist Taking Baron"      , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+            if not aram:
+                multiworld.get_location(champion_name + " - Assist Taking Dragon"     , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+                multiworld.get_location(champion_name + " - Assist Taking Rift Herald", player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+                multiworld.get_location(champion_name + " - Assist Taking Baron"      , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
             multiworld.get_location(champion_name + " - Assist Taking Tower"      , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
             multiworld.get_location(champion_name + " - Assist Taking Inhibitor"  , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+            multiworld.get_location(champion_name + " - Enemy Nexus Destroyed"    , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
             multiworld.get_location(champion_name + " - Get X Assists"            , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-            if "Support" in champions[champion_id]["tags"]:
+            if not aram and "Support" in champions[champion_id]["tags"]:
                 multiworld.get_location(champion_name + " - Get X Ward Score"     , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
             if "Support" not in champions[champion_id]["tags"]:
                 multiworld.get_location(champion_name + " - Get X Kills"          , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-                multiworld.get_location(champion_name + " - Get X Creep Score"    , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+                if not aram:
+                    multiworld.get_location(champion_name + " - Get X Creep Score"    , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
     
     # Win condition.
     multiworld.completion_condition[player] = lambda state: has_at_least(state, player, "LP", required_lp)

--- a/worlds/lol/Rules.py
+++ b/worlds/lol/Rules.py
@@ -9,20 +9,23 @@ def has_at_least(state: CollectionState, player: int, item_name, item_qty_requir
     return state.count(item_name, player) >= item_qty_required
 
 def set_rules(multiworld: MultiWorld, player: int, options, required_lp, possible_champions):
+    aram = bool(options.aram_mode)
     for champion_id in champions:
         champion_name = champions[champion_id]["name"]
         if champion_name in possible_champions:
-            multiworld.get_location(champion_name + " - Assist Taking Dragon"     , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-            multiworld.get_location(champion_name + " - Assist Taking Rift Herald", player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-            multiworld.get_location(champion_name + " - Assist Taking Baron"      , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+            if not aram:
+                multiworld.get_location(champion_name + " - Assist Taking Dragon"     , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+                multiworld.get_location(champion_name + " - Assist Taking Rift Herald", player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+                multiworld.get_location(champion_name + " - Assist Taking Baron"      , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
             multiworld.get_location(champion_name + " - Assist Taking Tower"      , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
             multiworld.get_location(champion_name + " - Assist Taking Inhibitor"  , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
             multiworld.get_location(champion_name + " - Get X Assists"            , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-            if "Support" in champions[champion_id]["tags"]:
+            if not aram and "Support" in champions[champion_id]["tags"]:
                 multiworld.get_location(champion_name + " - Get X Ward Score"     , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
             if "Support" not in champions[champion_id]["tags"]:
                 multiworld.get_location(champion_name + " - Get X Kills"          , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-                multiworld.get_location(champion_name + " - Get X Creep Score"    , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+                if not aram:
+                    multiworld.get_location(champion_name + " - Get X Creep Score"    , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
     
     # Win condition.
     multiworld.completion_condition[player] = lambda state: has_at_least(state, player, "LP", required_lp)

--- a/worlds/lol/Rules.py
+++ b/worlds/lol/Rules.py
@@ -9,24 +9,43 @@ def has_at_least(state: CollectionState, player: int, item_name, item_qty_requir
     return state.count(item_name, player) >= item_qty_required
 
 def set_rules(multiworld: MultiWorld, player: int, options, required_lp, possible_champions):
-    aram = bool(options.aram_mode)
+    enabled = set(options.enabled_checks.value) if getattr(options, 'enabled_checks', None) else None
+    sst = bool(getattr(options, 'support_special_treatment', True))
+
+    def check_enabled(check_name: str, is_support: bool) -> bool:
+        if enabled and check_name not in enabled:
+            return False
+        if sst:
+            if check_name == "Vision Score" and not is_support:
+                return False
+            if check_name in ("Kills", "Creep Score") and is_support:
+                return False
+        return True
+
     for champion_id in champions:
         champion_name = champions[champion_id]["name"]
         if champion_name in possible_champions:
-            if not aram:
+            is_support = "Support" in champions[champion_id]["tags"]
+            if check_enabled("Dragon", is_support):
                 multiworld.get_location(champion_name + " - Assist Taking Dragon"     , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+            if check_enabled("Herald", is_support):
                 multiworld.get_location(champion_name + " - Assist Taking Rift Herald", player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+            if check_enabled("Baron", is_support):
                 multiworld.get_location(champion_name + " - Assist Taking Baron"      , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-            multiworld.get_location(champion_name + " - Assist Taking Tower"      , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-            multiworld.get_location(champion_name + " - Assist Taking Inhibitor"  , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-            multiworld.get_location(champion_name + " - Enemy Nexus Destroyed"    , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-            multiworld.get_location(champion_name + " - Get X Assists"            , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-            if not aram and "Support" in champions[champion_id]["tags"]:
+            if check_enabled("Tower", is_support):
+                multiworld.get_location(champion_name + " - Assist Taking Tower"      , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+            if check_enabled("Inhibitor", is_support):
+                multiworld.get_location(champion_name + " - Assist Taking Inhibitor"  , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+            if check_enabled("Game Win", is_support):
+                multiworld.get_location(champion_name + " - Enemy Nexus Destroyed"    , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+            if check_enabled("Assists", is_support):
+                multiworld.get_location(champion_name + " - Get X Assists"            , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+            if check_enabled("Vision Score", is_support):
                 multiworld.get_location(champion_name + " - Get X Ward Score"     , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-            if "Support" not in champions[champion_id]["tags"]:
+            if check_enabled("Kills", is_support):
                 multiworld.get_location(champion_name + " - Get X Kills"          , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
-                if not aram:
-                    multiworld.get_location(champion_name + " - Get X Creep Score"    , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
+            if check_enabled("Creep Score", is_support):
+                multiworld.get_location(champion_name + " - Get X Creep Score"    , player).access_rule = lambda state, champion_name = champion_name: has_item(state, player, champion_name)
     
     # Win condition.
     multiworld.completion_condition[player] = lambda state: has_at_least(state, player, "LP", required_lp)

--- a/worlds/lol/__init__.py
+++ b/worlds/lol/__init__.py
@@ -1,14 +1,17 @@
-from typing import List
+from typing import List, TYPE_CHECKING
 
 from BaseClasses import Tutorial
 from worlds.AutoWorld import WebWorld, World
-from .Items import LOLItem, LOLItemData, event_item_table, get_items_by_category, item_table
+from .Items import LOLItem, item_table, get_items_by_category
 from .Locations import LOLLocation, location_table, get_locations_by_category
 from .Options import LOLOptions
 from .Regions import create_regions
 from .Rules import set_rules
 from .Data import champions
 from worlds.LauncherComponents import Component, components, Type, launch_subprocess
+
+if TYPE_CHECKING:
+    from BaseClasses import MultiWorld
 
 
 
@@ -36,6 +39,7 @@ class LOLWorld(World):
     League of Legends (LoL), commonly referred to as League, is a 2009 multiplayer online battle arena video game developed and published by Riot Games.
     """
     game = "League of Legends"
+    data_version = 1
     options_dataclass = LOLOptions
     options: LOLOptions
     topology_present = True
@@ -48,22 +52,30 @@ class LOLWorld(World):
     def __init__(self, multiworld: "MultiWorld", player: int):
         super(LOLWorld, self).__init__(multiworld, player)
         self.possible_champions = []
+        self.starting_champion_names = []
         self.added_lp = 0
 
     def create_items(self):
         item_pool: List[LOLItem] = []
         self.choose_possible_champions()
-        print(self.possible_champions)
-        starting_champions = self.random.sample(self.possible_champions, min(self.options.starting_champions, len(self.possible_champions)))
-        for i in range(len(starting_champions)):
-            self.multiworld.get_location("Starting Champion " + str(i+1), self.player).place_locked_item(self.create_item(starting_champions[i]))
+        self.choose_starting_champions()
+        for index, champion_name in enumerate(self.starting_champion_names, start=1):
+            self.multiworld.get_location("Starting Champion " + str(index), self.player).place_locked_item(self.create_item(champion_name))
+
         total_locations = len(self.multiworld.get_unfilled_locations(self.player))
         for name, data in item_table.items():
-            if name in self.possible_champions and name not in starting_champions:
+            if name in self.possible_champions and name not in self.starting_champion_names:
                 item_pool += [self.create_item(name) for _ in range(0, 1)]
-        while len(item_pool) < total_locations:
+
+        remaining_slots = max(0, total_locations - len(item_pool))
+        self.added_lp = min(int(self.options.total_lp_count), remaining_slots)
+        for _ in range(self.added_lp):
             item_pool.append(self.create_item("LP"))
-            self.added_lp += 1
+
+        filler_items = list(get_items_by_category("Filler", []).keys())
+        while len(item_pool) < total_locations:
+            item_pool.append(self.create_item(self.random.choice(filler_items)))
+
         self.multiworld.itempool += item_pool
         
     def create_item(self, name: str) -> LOLItem:
@@ -79,19 +91,67 @@ class LOLWorld(World):
         create_regions(self.multiworld, self.player, self.options, self.possible_champions)
     
     def fill_slot_data(self) -> dict:
+        self.choose_possible_champions()
+        self.choose_starting_champions()
         slot_data = {"Required CS":      int(self.options.required_creep_score)
                     ,"Required VS":      int(self.options.required_vision_score)
                     ,"Required Kills":   int(self.options.required_kills)
                     ,"Required Assists": int(self.options.required_assists)
-                    ,"Required LP":      int(self.added_lp * (self.options.required_lp / 100))}
+                    ,"Configured Total LP": int(self.options.total_lp_count)
+                    ,"Total LP":         int(self.added_lp)
+                    ,"Required LP Percentage": int(self.options.required_lp)
+                    ,"Required LP":      int(self.added_lp * (self.options.required_lp / 100))
+                    ,"Starting Champion Count": int(self.options.starting_champions)
+                    ,"Champion Subset Count": int(self.options.champion_subset_count)
+                    ,"ARAM Mode":        int(self.options.aram_mode)
+                    ,"Selected Champions": sorted(self.possible_champions)
+                    ,"Starting Champions": list(self.starting_champion_names)
+                    ,"Active Locations": self.get_active_location_names()}
         return slot_data
     
     def choose_possible_champions(self):
         if len(self.possible_champions) == 0:
-            print("Here")
             for champion_id in champions:
                 champion_name = champions[champion_id]["name"]
                 if champion_name in self.options.champions.value:
                     self.possible_champions.append(champion_name)
             if len(self.possible_champions) > self.options.champion_subset_count:
                 self.possible_champions = self.random.sample(self.possible_champions, self.options.champion_subset_count)
+
+    def choose_starting_champions(self):
+        if len(self.starting_champion_names) == 0:
+            self.choose_possible_champions()
+            self.starting_champion_names = self.random.sample(
+                self.possible_champions,
+                min(self.options.starting_champions, len(self.possible_champions))
+            )
+
+    def get_active_location_names(self) -> List[str]:
+        self.choose_possible_champions()
+        active_locations: List[str] = []
+        aram = bool(self.options.aram_mode)
+
+        for champion_id in champions:
+            champion_name = champions[champion_id]["name"]
+            if champion_name not in self.possible_champions:
+                continue
+            if not aram:
+                active_locations.append(champion_name + " - Assist Taking Dragon")
+                active_locations.append(champion_name + " - Assist Taking Rift Herald")
+                active_locations.append(champion_name + " - Assist Taking Baron")
+            active_locations.append(champion_name + " - Assist Taking Tower")
+            active_locations.append(champion_name + " - Assist Taking Inhibitor")
+            active_locations.append(champion_name + " - Get X Assists")
+            if not aram and "Support" in champions[champion_id]["tags"]:
+                active_locations.append(champion_name + " - Get X Ward Score")
+            if "Support" not in champions[champion_id]["tags"]:
+                active_locations.append(champion_name + " - Get X Kills")
+                if not aram:
+                    active_locations.append(champion_name + " - Get X Creep Score")
+
+        for index in range(1, min(int(self.options.starting_champions), len(self.possible_champions)) + 1):
+            active_locations.append("Starting Champion " + str(index))
+
+        active_locations.append("Game Win - Enemy Nexus Destroyed")
+
+        return active_locations

--- a/worlds/lol/__init__.py
+++ b/worlds/lol/__init__.py
@@ -1,14 +1,17 @@
-from typing import List
+from typing import List, TYPE_CHECKING
 
 from BaseClasses import Tutorial
 from worlds.AutoWorld import WebWorld, World
-from .Items import LOLItem, LOLItemData, event_item_table, get_items_by_category, item_table
+from .Items import LOLItem, item_table, get_items_by_category
 from .Locations import LOLLocation, location_table, get_locations_by_category
 from .Options import LOLOptions
 from .Regions import create_regions
 from .Rules import set_rules
 from .Data import champions
 from worlds.LauncherComponents import Component, components, Type, launch_subprocess
+
+if TYPE_CHECKING:
+    from BaseClasses import MultiWorld
 
 
 
@@ -36,6 +39,7 @@ class LOLWorld(World):
     League of Legends (LoL), commonly referred to as League, is a 2009 multiplayer online battle arena video game developed and published by Riot Games.
     """
     game = "League of Legends"
+    data_version = 1
     options_dataclass = LOLOptions
     options: LOLOptions
     topology_present = True
@@ -48,22 +52,30 @@ class LOLWorld(World):
     def __init__(self, multiworld: "MultiWorld", player: int):
         super(LOLWorld, self).__init__(multiworld, player)
         self.possible_champions = []
+        self.starting_champion_names = []
         self.added_lp = 0
 
     def create_items(self):
         item_pool: List[LOLItem] = []
         self.choose_possible_champions()
-        print(self.possible_champions)
-        starting_champions = self.random.sample(self.possible_champions, min(self.options.starting_champions, len(self.possible_champions)))
-        for i in range(len(starting_champions)):
-            self.multiworld.get_location("Starting Champion " + str(i+1), self.player).place_locked_item(self.create_item(starting_champions[i]))
+        self.choose_starting_champions()
+        for index, champion_name in enumerate(self.starting_champion_names, start=1):
+            self.multiworld.get_location("Starting Champion " + str(index), self.player).place_locked_item(self.create_item(champion_name))
+
         total_locations = len(self.multiworld.get_unfilled_locations(self.player))
         for name, data in item_table.items():
-            if name in self.possible_champions and name not in starting_champions:
+            if name in self.possible_champions and name not in self.starting_champion_names:
                 item_pool += [self.create_item(name) for _ in range(0, 1)]
-        while len(item_pool) < total_locations:
+
+        remaining_slots = max(0, total_locations - len(item_pool))
+        self.added_lp = min(int(self.options.total_lp_count), remaining_slots)
+        for _ in range(self.added_lp):
             item_pool.append(self.create_item("LP"))
-            self.added_lp += 1
+
+        filler_items = list(get_items_by_category("Filler", []).keys())
+        while len(item_pool) < total_locations:
+            item_pool.append(self.create_item(self.random.choice(filler_items)))
+
         self.multiworld.itempool += item_pool
         
     def create_item(self, name: str) -> LOLItem:
@@ -79,19 +91,66 @@ class LOLWorld(World):
         create_regions(self.multiworld, self.player, self.options, self.possible_champions)
     
     def fill_slot_data(self) -> dict:
+        self.choose_possible_champions()
+        self.choose_starting_champions()
         slot_data = {"Required CS":      int(self.options.required_creep_score)
                     ,"Required VS":      int(self.options.required_vision_score)
                     ,"Required Kills":   int(self.options.required_kills)
                     ,"Required Assists": int(self.options.required_assists)
-                    ,"Required LP":      int(self.added_lp * (self.options.required_lp / 100))}
+                    ,"Configured Total LP": int(self.options.total_lp_count)
+                    ,"Total LP":         int(self.added_lp)
+                    ,"Required LP Percentage": int(self.options.required_lp)
+                    ,"Required LP":      int(self.added_lp * (self.options.required_lp / 100))
+                    ,"Starting Champion Count": int(self.options.starting_champions)
+                    ,"Champion Subset Count": int(self.options.champion_subset_count)
+                    ,"ARAM Mode":        int(self.options.aram_mode)
+                    ,"Selected Champions": sorted(self.possible_champions)
+                    ,"Starting Champions": list(self.starting_champion_names)
+                    ,"Active Locations": self.get_active_location_names()}
         return slot_data
     
     def choose_possible_champions(self):
         if len(self.possible_champions) == 0:
-            print("Here")
             for champion_id in champions:
                 champion_name = champions[champion_id]["name"]
                 if champion_name in self.options.champions.value:
                     self.possible_champions.append(champion_name)
             if len(self.possible_champions) > self.options.champion_subset_count:
                 self.possible_champions = self.random.sample(self.possible_champions, self.options.champion_subset_count)
+
+    def choose_starting_champions(self):
+        if len(self.starting_champion_names) == 0:
+            self.choose_possible_champions()
+            self.starting_champion_names = self.random.sample(
+                self.possible_champions,
+                min(self.options.starting_champions, len(self.possible_champions))
+            )
+
+    def get_active_location_names(self) -> List[str]:
+        self.choose_possible_champions()
+        active_locations: List[str] = []
+        aram = bool(self.options.aram_mode)
+
+        for champion_id in champions:
+            champion_name = champions[champion_id]["name"]
+            if champion_name not in self.possible_champions:
+                continue
+            if not aram:
+                active_locations.append(champion_name + " - Assist Taking Dragon")
+                active_locations.append(champion_name + " - Assist Taking Rift Herald")
+                active_locations.append(champion_name + " - Assist Taking Baron")
+            active_locations.append(champion_name + " - Assist Taking Tower")
+            active_locations.append(champion_name + " - Assist Taking Inhibitor")
+            active_locations.append(champion_name + " - Enemy Nexus Destroyed")
+            active_locations.append(champion_name + " - Get X Assists")
+            if not aram and "Support" in champions[champion_id]["tags"]:
+                active_locations.append(champion_name + " - Get X Ward Score")
+            if "Support" not in champions[champion_id]["tags"]:
+                active_locations.append(champion_name + " - Get X Kills")
+                if not aram:
+                    active_locations.append(champion_name + " - Get X Creep Score")
+
+        for index in range(1, min(int(self.options.starting_champions), len(self.possible_champions)) + 1):
+            active_locations.append("Starting Champion " + str(index))
+
+        return active_locations

--- a/worlds/lol/__init__.py
+++ b/worlds/lol/__init__.py
@@ -1,10 +1,10 @@
-from typing import List, TYPE_CHECKING
+from typing import Any, List, TYPE_CHECKING
 
 from BaseClasses import Tutorial
 from worlds.AutoWorld import WebWorld, World
 from .Items import LOLItem, item_table, get_items_by_category
-from .Locations import LOLLocation, location_table, get_locations_by_category
-from .Options import LOLOptions
+from .Locations import LOLLocation, location_table, get_locations_by_category, get_champion_location_suffixes
+from .Options import LOLOptions, lol_option_groups
 from .Regions import create_regions
 from .Rules import set_rules
 from .Data import champions
@@ -17,13 +17,14 @@ if TYPE_CHECKING:
 
 def launch_client():
     from .Client import launch
-    launch_subprocess(launch, name="LOL Client")
+    launch_subprocess(launch, name="LoL Client")
 
 
-components.append(Component("LOL Client", "LOLClient", func=launch_client, component_type=Type.CLIENT))
+components.append(Component("LoL Client", "LOLClient", func=launch_client, component_type=Type.CLIENT))
 
 class LOLWeb(WebWorld):
     theme = "ocean"
+    option_groups = lol_option_groups
     tutorials = [Tutorial(
         "Multiworld Setup Guide",
         "A guide to setting up the League of Legends AP Randomizer software on your computer. This guide covers single-player, "
@@ -39,11 +40,12 @@ class LOLWorld(World):
     League of Legends (LoL), commonly referred to as League, is a 2009 multiplayer online battle arena video game developed and published by Riot Games.
     """
     game = "League of Legends"
-    data_version = 1
+    data_version = 2.1
     options_dataclass = LOLOptions
     options: LOLOptions
     topology_present = True
     required_client_version = (0, 3, 5)
+    ut_can_gen_without_yaml = True
     web = LOLWeb()
 
     item_name_to_id = {name: data.code for name, data in item_table.items()}
@@ -54,6 +56,31 @@ class LOLWorld(World):
         self.possible_champions = []
         self.starting_champion_names = []
         self.added_lp = 0
+
+    def generate_early(self):
+        re_gen_passthrough = getattr(self.multiworld, "re_gen_passthrough", {})
+        if self.game not in re_gen_passthrough:
+            return
+
+        slot_data: dict[str, Any] = re_gen_passthrough[self.game]
+        slot_options: dict[str, Any] = slot_data.get("options", {})
+        for option_name, option_value in slot_options.items():
+            option = getattr(self.options, option_name, None)
+            if option is None:
+                continue
+            parsed_option = type(option).from_any(option_value)
+            self.options.__setattr__(option_name, parsed_option)
+
+        # Restore the exact champions chosen during the original generation so that
+        # create_regions / set_rules / create_items recreate the same logic rather
+        # than picking a new random subset.
+        if "Selected Champions" in slot_data:
+            self.possible_champions = list(slot_data["Selected Champions"])
+        if "Starting Champions" in slot_data:
+            self.starting_champion_names = list(slot_data["Starting Champions"])
+        # Restore added_lp so the LP win-condition threshold in set_rules is correct.
+        if "Total LP" in slot_data:
+            self.added_lp = int(slot_data["Total LP"])
 
     def create_items(self):
         item_pool: List[LOLItem] = []
@@ -103,10 +130,31 @@ class LOLWorld(World):
                     ,"Required LP":      int(self.added_lp * (self.options.required_lp / 100))
                     ,"Starting Champion Count": int(self.options.starting_champions)
                     ,"Champion Subset Count": int(self.options.champion_subset_count)
-                    ,"ARAM Mode":        int(self.options.aram_mode)
+                    ,"Win Completes Champion": int(self.options.win_completes_champion)
+                    ,"Enabled Checks":        sorted(list(self.options.enabled_checks.value))
+                    ,"Support Special Treatment": int(self.options.support_special_treatment)
                     ,"Selected Champions": sorted(self.possible_champions)
                     ,"Starting Champions": list(self.starting_champion_names)
-                    ,"Active Locations": self.get_active_location_names()}
+                    ,"options": self.options.as_dict(
+                        "champions",
+                        "required_creep_score",
+                        "required_vision_score",
+                        "required_kills",
+                        "required_assists",
+                        "total_lp_count",
+                        "required_lp",
+                        "starting_champions",
+                        "champion_subset_count",
+                        "enabled_checks",
+                        "support_special_treatment",
+                        "win_completes_champion"
+                    )
+                    ,"Active Locations": self.get_active_location_names()
+                    ,"Active Location IDs": {name: self.location_name_to_id.get(name) for name in self.get_active_location_names()}}
+        return slot_data
+
+    @staticmethod
+    def interpret_slot_data(slot_data: dict[str, Any]) -> dict[str, Any]:
         return slot_data
     
     def choose_possible_champions(self):
@@ -129,26 +177,15 @@ class LOLWorld(World):
     def get_active_location_names(self) -> List[str]:
         self.choose_possible_champions()
         active_locations: List[str] = []
-        aram = bool(self.options.aram_mode)
+        enabled_checks = self.options.enabled_checks.value
+        sst = bool(self.options.support_special_treatment)
 
         for champion_id in champions:
             champion_name = champions[champion_id]["name"]
             if champion_name not in self.possible_champions:
                 continue
-            if not aram:
-                active_locations.append(champion_name + " - Assist Taking Dragon")
-                active_locations.append(champion_name + " - Assist Taking Rift Herald")
-                active_locations.append(champion_name + " - Assist Taking Baron")
-            active_locations.append(champion_name + " - Assist Taking Tower")
-            active_locations.append(champion_name + " - Assist Taking Inhibitor")
-            active_locations.append(champion_name + " - Enemy Nexus Destroyed")
-            active_locations.append(champion_name + " - Get X Assists")
-            if not aram and "Support" in champions[champion_id]["tags"]:
-                active_locations.append(champion_name + " - Get X Ward Score")
-            if "Support" not in champions[champion_id]["tags"]:
-                active_locations.append(champion_name + " - Get X Kills")
-                if not aram:
-                    active_locations.append(champion_name + " - Get X Creep Score")
+            for suffix in get_champion_location_suffixes(champion_id, enabled_checks, sst):
+                active_locations.append(champion_name + suffix)
 
         for index in range(1, min(int(self.options.starting_champions), len(self.possible_champions)) + 1):
             active_locations.append("Starting Champion " + str(index))

--- a/worlds/lol/__init__.py
+++ b/worlds/lol/__init__.py
@@ -111,7 +111,15 @@ class LOLWorld(World):
 
     def set_rules(self):
         self.choose_possible_champions()
-        set_rules(self.multiworld, self.player, self.options, int(self.added_lp * (self.options.required_lp / 100)), self.possible_champions)
+        required_lp = self._compute_required_lp()
+        set_rules(self.multiworld, self.player, self.options, required_lp, self.possible_champions)
+
+    def _compute_required_lp(self) -> int:
+        pct = float(self.options.required_lp) / 100.0
+        raw = self.added_lp * pct
+        if raw < 1:
+            return 1
+        return int(raw)
 
     def create_regions(self):
         self.choose_possible_champions()
@@ -127,7 +135,7 @@ class LOLWorld(World):
                     ,"Configured Total LP": int(self.options.total_lp_count)
                     ,"Total LP":         int(self.added_lp)
                     ,"Required LP Percentage": int(self.options.required_lp)
-                    ,"Required LP":      int(self.added_lp * (self.options.required_lp / 100))
+                    ,"Required LP":      int(self._compute_required_lp())
                     ,"Starting Champion Count": int(self.options.starting_champions)
                     ,"Champion Subset Count": int(self.options.champion_subset_count)
                     ,"Win Completes Champion": int(self.options.win_completes_champion)

--- a/worlds/lol/archipelago.json
+++ b/worlds/lol/archipelago.json
@@ -1,0 +1,6 @@
+{
+	"game": "League of Legends",
+	"minimum_ap_version": "0.6.6",
+	"world_version": "0.2.1",
+	"authors": ["kbab"]
+}

--- a/worlds/lol/archipelago.json
+++ b/worlds/lol/archipelago.json
@@ -1,6 +1,6 @@
 {
 	"game": "League of Legends",
 	"minimum_ap_version": "0.6.6",
-	"world_version": "0.2.1_hotfix",
+	"world_version": "0.2.2",
 	"authors": ["kbab"]
 }

--- a/worlds/lol/archipelago.json
+++ b/worlds/lol/archipelago.json
@@ -1,6 +1,6 @@
 {
 	"game": "League of Legends",
 	"minimum_ap_version": "0.6.6",
-	"world_version": "0.2.1",
+	"world_version": "0.2.1_hotfix",
 	"authors": ["kbab"]
 }

--- a/worlds/lol/archipelago.json
+++ b/worlds/lol/archipelago.json
@@ -1,6 +1,6 @@
 {
 	"game": "League of Legends",
 	"minimum_ap_version": "0.6.6",
-	"world_version": "0.2.3",
+	"world_version": "0.2.4",
 	"authors": ["kbab"]
 }

--- a/worlds/lol/archipelago.json
+++ b/worlds/lol/archipelago.json
@@ -1,6 +1,6 @@
 {
 	"game": "League of Legends",
 	"minimum_ap_version": "0.6.6",
-	"world_version": "0.2.4",
+	"world_version": "0.2.5",
 	"authors": ["kbab"]
 }

--- a/worlds/lol/archipelago.json
+++ b/worlds/lol/archipelago.json
@@ -1,6 +1,6 @@
 {
 	"game": "League of Legends",
 	"minimum_ap_version": "0.6.6",
-	"world_version": "0.2.2",
+	"world_version": "0.2.3",
 	"authors": ["kbab"]
 }

--- a/worlds/lol/connector.spec
+++ b/worlds/lol/connector.spec
@@ -1,0 +1,38 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['Connector.py'],
+    pathex=[],
+    binaries=[],
+    datas=[('archipelago.json', '.')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='Connector',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)


### PR DESCRIPTION
- ARAM mode: only enables Tower, Inhibitor, Assists, and Kills checks
- Added champion-specific Enemy Nexus Destroyed locations
- Added filler items to the LoL world item pool, Option to set the number of LP in the item pool
- Added co-op mode support in the connector: can count selected teammates actions toward checks
- Increased the maximum starting champion count
- Added yaml-less Universal Tracker support